### PR TITLE
[Feature/response] response entity 와 커스텀 error 생성

### DIFF
--- a/src/main/java/com/feelmycode/parabole/global/api/ParaboleResponse.java
+++ b/src/main/java/com/feelmycode/parabole/global/api/ParaboleResponse.java
@@ -1,0 +1,32 @@
+package com.feelmycode.parabole.global.api;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+public class ParaboleResponse {
+
+    private boolean success;
+    private String message;
+    private Object data;
+
+    private ParaboleResponse(boolean success, String message, Object data) {
+        this.success = success;
+        this.message = message;
+        this.data = data;
+    }
+
+    private ParaboleResponse(boolean success, String message) {
+        this.success = success;
+        this.message = message;
+    }
+
+    public static ResponseEntity<ParaboleResponse> CommonResponse(HttpStatus httpStatus, boolean success, String message, Object data) {
+        return ResponseEntity.status(httpStatus).body(new ParaboleResponse(success, message, data));
+    }
+
+    public static ResponseEntity<ParaboleResponse> CommonResponse(HttpStatus httpStatus, boolean success, String message) {
+        return ResponseEntity.status(httpStatus).body(new ParaboleResponse(success, message));
+    }
+}

--- a/src/main/java/com/feelmycode/parabole/global/error/ParaboleExceptionHandler.java
+++ b/src/main/java/com/feelmycode/parabole/global/error/ParaboleExceptionHandler.java
@@ -1,0 +1,29 @@
+package com.feelmycode.parabole.global.error;
+
+import com.feelmycode.parabole.global.api.ParaboleResponse;
+import com.feelmycode.parabole.global.error.exception.ParaboleException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+class ParaboleExceptionHandler extends Exception {
+
+    private final boolean SUCCESS = false;
+
+    @ExceptionHandler(ParaboleException.class)
+    protected ResponseEntity<ParaboleResponse> handleGlobalBusinessException(ParaboleException e) {
+        String message = e.getMessage();
+        HttpStatus httpStatus = e.getHttpStatus();
+        return ParaboleResponse.CommonResponse(httpStatus, SUCCESS, message);
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ParaboleResponse> handleException(Exception e) {
+
+        String message = e.getMessage();
+
+        return ParaboleResponse.CommonResponse(HttpStatus.INTERNAL_SERVER_ERROR, SUCCESS, message);
+    }
+}

--- a/src/main/java/com/feelmycode/parabole/global/error/exception/ParaboleException.java
+++ b/src/main/java/com/feelmycode/parabole/global/error/exception/ParaboleException.java
@@ -1,0 +1,15 @@
+package com.feelmycode.parabole.global.error.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ParaboleException extends RuntimeException{
+
+    private final HttpStatus httpStatus;
+
+    public ParaboleException(HttpStatus httpStatus, String message) {
+        super(message);
+        this.httpStatus = httpStatus;
+    }
+}


### PR DESCRIPTION
## 개요
우리 프로젝트만의 api 사용법과 exception을 위해 작성

## 작업한 내용
- response entity 생성
- 커스텀 error 생성

## 리뷰 가이드 
에러없는것을 확인했습니다. 혹시 있는지 살펴보세요
앞으로 각자 적용하는 방법을 생각해보세요! 월요일에 적용해보겠습니다.

## 테스트 결과
1. response
![스크린샷 2022-09-23 오후 3 10 22](https://user-images.githubusercontent.com/52902010/191901393-857124bb-52f8-498a-b0dd-da5e54e3bf60.png)

2. exception
![image](https://user-images.githubusercontent.com/52902010/191901127-8f6e3b55-25c4-4671-a116-163f93c7fd2d.png)

## 앞으로 추가 예정 내용
각자 적용하시고 error 경우는 그대로 사용해도 되고 커스텀해서 사용해도 됩니다.

## 이슈번호
[#26][#31]
