### PR TITLE
[Fix/event] Event에 Response Entity 및 Custom Error 적용

### DIFF
--- a/src/main/java/com/feelmycode/parabole/controller/EventController.java
+++ b/src/main/java/com/feelmycode/parabole/controller/EventController.java
@@ -56,9 +56,9 @@ public class EventController {
     public ResponseEntity<ParaboleResponse> cancelEvent(@PathVariable("eventId") Long eventId) {
         try {
             eventService.cancelEvent(eventId);
-            return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "이벤트 취소 성공");
         } catch (Exception e) {
             throw new ParaboleException(HttpStatus.INTERNAL_SERVER_ERROR, "이벤트 취소 실패");
         }
+        return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "이벤트 취소 성공");
     }
 }

--- a/src/main/java/com/feelmycode/parabole/controller/EventController.java
+++ b/src/main/java/com/feelmycode/parabole/controller/EventController.java
@@ -3,11 +3,15 @@ package com.feelmycode.parabole.controller;
 import com.feelmycode.parabole.domain.Event;
 import com.feelmycode.parabole.dto.EventCreateRequestDto;
 import com.feelmycode.parabole.dto.EventListResponseDto;
+import com.feelmycode.parabole.global.api.ParaboleResponse;
+import com.feelmycode.parabole.global.error.exception.ParaboleException;
 import com.feelmycode.parabole.service.EventService;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,29 +27,38 @@ public class EventController {
     private final EventService eventService;
 
     @PostMapping()
-    public ResponseEntity<?> createEvent(@RequestBody EventCreateRequestDto eventDto) {
+    public ResponseEntity<ParaboleResponse> createEvent(@RequestBody EventCreateRequestDto eventDto) {
         try {
             Long eventId = eventService.createEvent(eventDto);
-            return ResponseEntity.ok(eventId);
+            return ParaboleResponse.CommonResponse(HttpStatus.CREATED, true, "이벤트 등록 성공", eventId);
         } catch (Exception e) {
-            String error = e.getMessage();
-            return ResponseEntity.badRequest().body(error);
+            throw new ParaboleException(HttpStatus.INTERNAL_SERVER_ERROR, "이벤트 등록 실패");
         }
     }
 
     @GetMapping("/{eventId}")
-    public ResponseEntity<EventListResponseDto> getEvent(@PathVariable("eventId") Long eventId) {
+    public ResponseEntity<ParaboleResponse> getEvent(@PathVariable("eventId") Long eventId) {
         Event eventEntity = eventService.getEventByEventId(eventId);
         EventListResponseDto response = EventListResponseDto.of(eventEntity);
-        return ResponseEntity.ok(response);
+        return ParaboleResponse.CommonResponse(HttpStatus.OK, true, eventId+"번 이벤트 조회 성공", response);
     }
 
     @GetMapping()
-    public ResponseEntity<List<EventListResponseDto>> getEvent() {
+    public ResponseEntity<ParaboleResponse> getEvent() {
         List<Event> eventEntities = eventService.getEventsAllNotDeleted();
         List<EventListResponseDto> response = eventEntities.stream()
             .map(EventListResponseDto::of)
             .collect(Collectors.toList());
-        return ResponseEntity.ok(response);
+        return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "이벤트 리스트 조회 성공", response);
+    }
+
+    @DeleteMapping("/{eventId}")
+    public ResponseEntity<ParaboleResponse> cancelEvent(@PathVariable("eventId") Long eventId) {
+        try {
+            eventService.cancelEvent(eventId);
+            return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "이벤트 취소 성공");
+        } catch (Exception e) {
+            throw new ParaboleException(HttpStatus.INTERNAL_SERVER_ERROR, "이벤트 취소 실패");
+        }
     }
 }

--- a/src/main/java/com/feelmycode/parabole/controller/EventController.java
+++ b/src/main/java/com/feelmycode/parabole/controller/EventController.java
@@ -28,12 +28,13 @@ public class EventController {
 
     @PostMapping()
     public ResponseEntity<ParaboleResponse> createEvent(@RequestBody EventCreateRequestDto eventDto) {
+        Long eventId = -1L;
         try {
-            Long eventId = eventService.createEvent(eventDto);
-            return ParaboleResponse.CommonResponse(HttpStatus.CREATED, true, "이벤트 등록 성공", eventId);
+            eventId = eventService.createEvent(eventDto);
         } catch (Exception e) {
             throw new ParaboleException(HttpStatus.INTERNAL_SERVER_ERROR, "이벤트 등록 실패");
         }
+        return ParaboleResponse.CommonResponse(HttpStatus.CREATED, true, "이벤트 등록 성공", eventId);
     }
 
     @GetMapping("/{eventId}")

--- a/src/main/java/com/feelmycode/parabole/domain/EventPrize.java
+++ b/src/main/java/com/feelmycode/parabole/domain/EventPrize.java
@@ -17,7 +17,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "event_prize")
+@Table(name = "event_prizes")
 @Getter
 @NoArgsConstructor
 public class EventPrize {
@@ -41,7 +41,7 @@ public class EventPrize {
     private Coupon coupon;
 
     @ManyToOne
-    @JoinColumn(name = "prodcut_id")
+    @JoinColumn(name = "product_id")
     @JsonBackReference
     private Product product;
 

--- a/src/main/java/com/feelmycode/parabole/dto/EventCreateRequestDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/EventCreateRequestDto.java
@@ -1,6 +1,8 @@
 package com.feelmycode.parabole.dto;
 
 import com.feelmycode.parabole.domain.EventImage;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -15,10 +17,10 @@ public class EventCreateRequestDto {
     private String createdBy;
     private String type;
     private String title;
-    private String startAt;
-    private String endAt;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
     private String descript;
     private EventImage eventImage;
-    private EventPrizeCreateRequestDto eventPrizeCreateRequestDtos;
+    private List<EventPrizeCreateRequestDto> eventPrizeCreateRequestDtos;
 
 }

--- a/src/main/java/com/feelmycode/parabole/dto/EventListResponseDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/EventListResponseDto.java
@@ -3,7 +3,7 @@ package com.feelmycode.parabole.dto;
 import com.feelmycode.parabole.domain.Event;
 import com.feelmycode.parabole.domain.EventImage;
 import com.feelmycode.parabole.domain.EventPrize;
-import java.time.format.DateTimeFormatter;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -23,8 +23,8 @@ public class EventListResponseDto {
     private String createdBy;
     private String type;
     private String title;
-    private String startAt;
-    private String endAt;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
     private Integer status;
     private String descript;
     private EventImage eventImage;
@@ -38,8 +38,8 @@ public class EventListResponseDto {
             .createdBy(event.getCreatedBy())
             .type(event.getType())
             .title(event.getTitle())
-            .startAt(event.getStartAt().format(DateTimeFormatter.ofPattern("yyyy-MM-ddTHH:mm:ss")))
-            .endAt(event.getEndAt().format(DateTimeFormatter.ofPattern("yyyy-MM-ddTHH:mm:ss")))
+            .startAt(event.getStartAt())
+            .endAt(event.getEndAt())
             .status(event.getStatus())
             .descript(event.getDescript())
             .eventImage(event.getEventImage())

--- a/src/main/java/com/feelmycode/parabole/dto/EventPrizeCreateRequestDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/EventPrizeCreateRequestDto.java
@@ -11,9 +11,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class EventPrizeCreateRequestDto {
 
+    private Long id;
     private String type;
     private Integer stock;
-    private List<Long> productIds;
-    private List<Long> couponIds;
 
 }

--- a/src/main/java/com/feelmycode/parabole/service/EventService.java
+++ b/src/main/java/com/feelmycode/parabole/service/EventService.java
@@ -2,23 +2,22 @@ package com.feelmycode.parabole.service;
 
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 
-import com.feelmycode.parabole.domain.Coupon;
+//import com.feelmycode.parabole.domain.Coupon;
+//import com.feelmycode.parabole.domain.Seller;
+//import com.feelmycode.parabole.repository.CouponRepository;
+//import com.feelmycode.parabole.repository.SellerRepository;
 import com.feelmycode.parabole.domain.Event;
 import com.feelmycode.parabole.domain.EventPrize;
 import com.feelmycode.parabole.domain.Product;
-import com.feelmycode.parabole.domain.Seller;
 import com.feelmycode.parabole.dto.EventCreateRequestDto;
-import com.feelmycode.parabole.global.error.IdNotFoundException;
-import com.feelmycode.parabole.repository.CouponRepository;
+import com.feelmycode.parabole.global.error.exception.ParaboleException;
 import com.feelmycode.parabole.repository.EventRepository;
 import com.feelmycode.parabole.repository.ProductRepository;
-import com.feelmycode.parabole.repository.SellerRepository;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
@@ -37,32 +36,33 @@ public class EventService {
     private final ProductRepository productRepository;
 
     /**
-     *  이벤트 생성
+     * 이벤트 생성
      */
     @Transactional
     public Long createEvent(EventCreateRequestDto eventDto) {
 
         // 엔티티 조회
-        // TODO : Error Exception 수정
-        //Seller seller = sellerRepository.findById(eventDto.getSellerId()).orElseThrow(() -> new IdNotFoundException("해당하는 ID의 판매자가 없습니다."));
+        //Seller seller = sellerRepository.findById(eventDto.getSellerId()).orElseThrow(() -> new ParaboleException(HttpStatus.NOT_FOUND, "해당하는 ID의 판매자가 없습니다")));
         Long sellerId = eventDto.getSellerId();
 
         List<Long> productIds = eventDto.getEventPrizeCreateRequestDtos().getProductIds();
-        List<Long> couponIds  = eventDto.getEventPrizeCreateRequestDtos().getCouponIds();
+        List<Long> couponIds = eventDto.getEventPrizeCreateRequestDtos().getCouponIds();
 
         // 이벤트-경품정보 생성
         List<EventPrize> eventPrizeList = new ArrayList<>();
 
         if (CollectionUtils.isEmpty(productIds)) {
             for (Long productId : productIds) {
-                Product product = productRepository.findById(productId).orElseThrow(() -> new IdNotFoundException("해당하는 ID의 상품이 없습니다."));
-                EventPrize productPrize = new EventPrize("PRODUCT", eventDto.getEventPrizeCreateRequestDtos().getStock(), product);
+                Product product = productRepository.findById(productId).orElseThrow(() ->
+                    new ParaboleException(HttpStatus.NOT_FOUND, "해당하는 ID의 상품이 없습니다."));
+                eventPrizeList.add(new EventPrize("PRODUCT",
+                    eventDto.getEventPrizeCreateRequestDtos().getStock(), product));
             }
         }
 
 //        if (CollectionUtils.isEmpty(productIds)) {
 //            for (Long couponId : couponIds) {
-//                Coupon coupon = couponRepository.findById(couponId).orElseThrow(() -> new IdNotFoundException("해당하는 ID의 쿠폰이 없습니다."));
+//                Coupon coupon = couponRepository.findById(couponId).orElseThrow(() -> new ParaboleException(HttpStatus.NOT_FOUND, "해당하는 ID의 쿠폰이 없습니다"));
 //                EventPrize couponPrize = new EventPrize("COUPON", eventDto.getEventPrizeCreateRequestDtos().getStock(), coupon);
 //                eventPrizeList.add(couponPrize);
 //            }
@@ -91,7 +91,8 @@ public class EventService {
      * 이벤트 ID로 단건 조회
      */
     public Event getEventByEventId(Long eventId) {
-        return eventRepository.findById(eventId).orElseThrow();
+        return eventRepository.findById(eventId).orElseThrow(
+            () -> new ParaboleException(HttpStatus.NOT_FOUND, "해당하는 ID의 이벤트가 없습니다"));
     }
 
     /**
@@ -102,8 +103,7 @@ public class EventService {
     }
 
     /**
-     * 이벤트 전체 조회
-     * (삭제된 이벤트 제외)
+     * 이벤트 전체 조회 (삭제된 이벤트 제외)
      */
     public List<Event> getEventsAllNotDeleted() {
         return eventRepository.findAllByIsDeleted(false);
@@ -115,10 +115,12 @@ public class EventService {
      */
     @Transactional
     public void cancelEvent(Long eventId) {
-        Optional<Event> event = eventRepository.findById(eventId);
-        event.ifPresent(e -> {
-            e.cancel();
-            eventRepository.save(e);
-        });
+        Event event = eventRepository.findById(eventId).orElseThrow(()-> new ParaboleException(HttpStatus.NOT_FOUND, "해당하는 ID의 이벤트를 찾을 수 없습니다"));
+        try {
+            event.cancel();
+            eventRepository.save(event);
+        } catch (Exception e) {
+            throw new ParaboleException(HttpStatus.INTERNAL_SERVER_ERROR, "이벤트 등록 실패");
+        }
     }
 }

--- a/src/test/java/com/feelmycode/parabole/service/eventServiceTest.java
+++ b/src/test/java/com/feelmycode/parabole/service/eventServiceTest.java
@@ -35,18 +35,26 @@ public class eventServiceTest {
     EventService eventService;
 
     @Test
+    public void 이벤트_에러_테스트() throws Exception {
+        //given
+        Long eventId = 100L;
+
+        //when
+        Event event = eventService.getEventByEventId(eventId);
+    }
+
+    @Test
     public void 이벤트등록() throws Exception {
         //given
         //셀러와 상품(1,2) 데이터가 있다고 간주
-        List<Long> productIds = new ArrayList<>();
-        productIds.add(1L);
-        productIds.add(2L);
+        List<EventPrizeCreateRequestDto> prizes = new ArrayList<>();
+        prizes.add(new EventPrizeCreateRequestDto(1L, "PRODUCT", 50));
+        prizes.add(new EventPrizeCreateRequestDto(2L, "PRODUCT", 100));
 
         LocalDateTime startAt = LocalDateTime.parse("2022-09-22T00:00:00", ISO_LOCAL_DATE_TIME);
         LocalDateTime endAt = LocalDateTime.parse("2022-09-28T18:00:00", ISO_LOCAL_DATE_TIME);
 
-        EventPrizeCreateRequestDto eventPrizeCreateRequestDto = new EventPrizeCreateRequestDto("FCFS", 50, productIds, null);
-        EventCreateRequestDto testEventDto = new EventCreateRequestDto(1L, "SELLER", "RAFFLE", "테스트등록이벤트", startAt+"", endAt+"","테스트 등록 이벤트 설명", new EventImage(), eventPrizeCreateRequestDto);
+        EventCreateRequestDto testEventDto = new EventCreateRequestDto(1L, "SELLER", "RAFFLE", "테스트등록이벤트", startAt, endAt,"테스트 등록 이벤트 설명", new EventImage(), prizes);
 
         //when
         Long eventId = eventService.createEvent(testEventDto);


### PR DESCRIPTION
## 개요
Event에 Response Entity 및 Custom Error 적용

## 작업한 내용
- Event에 Response Entity 및 Custom Error 적용
- 컬럼,테이블명 수정
- 이벤트 생성 로직 오류를 수정

## 리뷰 가이드 
- 적절한 HTTP 상태코드인지, 적절히 사용했는지 봐주세요.
- 이벤트 생성 로직 확인해주세요

## 테스트 결과
![image](https://user-images.githubusercontent.com/37797830/192213660-1df48f29-903a-4127-9b3e-a0238627eddd.png)

## 기타 내용
api 명세 수정 예정

## 이슈번호
[#50]
