### PR TITLE
[feature/user] jpa 적용 중 User, Seller Entity 공동 수정 작업

### DIFF
--- a/src/main/java/com/feelmycode/parabole/controller/SellerController.java
+++ b/src/main/java/com/feelmycode/parabole/controller/SellerController.java
@@ -20,7 +20,7 @@ public class SellerController {
     private final SellerService sellerService;
 
     @GetMapping("/info")
-    public ResponseEntity<ParaboleResponse> getSellerInfo(@RequestParam Long sellerId) {
+    public ResponseEntity<ParaboleResponse> getSellerInfo(@RequestParam("sellerId") Long sellerId) {
 
         Seller seller = sellerService.getSellerInfo(sellerId);
         return ParaboleResponse.CommonResponse(HttpStatus.OK,

--- a/src/main/java/com/feelmycode/parabole/controller/UserController.java
+++ b/src/main/java/com/feelmycode/parabole/controller/UserController.java
@@ -26,7 +26,7 @@ public class UserController {
 
     private final UserService userService;
 
-    @PostMapping()
+    @PostMapping
     public ResponseEntity<ParaboleResponse> signup(@RequestBody UserSignupDto dto) {
 
         User newUser = userService.signup(dto);
@@ -34,7 +34,7 @@ public class UserController {
             true, "사용자: 회원가입 성공");
     }
 
-    @GetMapping()
+    @GetMapping
     public ResponseEntity<ParaboleResponse> signin(@RequestBody UserSigninDto dto) {
 
         if (!userService.signin(dto)) {
@@ -44,19 +44,19 @@ public class UserController {
     }
 
     @GetMapping("/role")
-    public ResponseEntity<ParaboleResponse> checkAccountRole(@RequestParam String email) {
+    public ResponseEntity<ParaboleResponse> checkAccountRole(@RequestParam Long userId) {
         // TODO: Role을 enum타입을 사용할 수 있게 변경
-        if (userService.checkAccountRole(email) == 1) {
+        if (userService.isUser(userId)) {
             return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "계정은 Role 은 사용자(USER) 입니다.", "USER");
         }
         return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "계정은 Role 은 판매자(SELLER) 입니다.", "SELLER");
     }
 
     @GetMapping("/{userId}")
-    public ResponseEntity<ParaboleResponse> myPageUserInfo(@PathVariable("userId") Long userId) {
+    public ResponseEntity<ParaboleResponse> getUserInfo(@PathVariable("userId") Long userId) {
 
         return ParaboleResponse.CommonResponse(HttpStatus.OK, true,
-            "마이페이지 사용자 개인정보 정상 출력", userService.myPageUserInfo(userId));
+            "마이페이지 사용자 개인정보 정상 출력", userService.getUserInfo(userId));
     }
 
 }

--- a/src/main/java/com/feelmycode/parabole/domain/Seller.java
+++ b/src/main/java/com/feelmycode/parabole/domain/Seller.java
@@ -44,7 +44,6 @@ public class Seller extends BaseEntity {
     }
 
     public void setUser(User user) {
-        user.setSeller(this);     // owner
         this.user = user;
     }
 

--- a/src/main/java/com/feelmycode/parabole/domain/User.java
+++ b/src/main/java/com/feelmycode/parabole/domain/User.java
@@ -53,14 +53,17 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user")
     private List<UserCoupon> userCoupons = new ArrayList<>();
 
-    /** 연관관계 메서드 */
-    public void setUserCoupon(UserCoupon userCoupon){
-        userCoupon.setUser(this);               // owner
-        this.getUserCoupons().add(userCoupon);
+    /** User 에게 판매자 권한을 부여하는 것을 오직 Admin 만 가능하기에 함수 사용할 일 X */
+    public void setSeller(Seller seller) {
+        seller.setUser(this);
+        this.seller = seller;
     }
 
-    public void setSeller(Seller seller) {
-        this.seller = seller;
+    public String checkRole() {
+        if (seller != null) {
+            return "SELLER";
+        }
+        return "USER";
     }
 
     public User(String email, String name,

--- a/src/main/java/com/feelmycode/parabole/repository/SellerRepository.java
+++ b/src/main/java/com/feelmycode/parabole/repository/SellerRepository.java
@@ -6,5 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface SellerRepository extends JpaRepository<Seller, Long> {
 
     Seller findByRegistrationNo(String registrationNo);
+    Seller findByStoreName(String storeName);
 
 }

--- a/src/main/java/com/feelmycode/parabole/repository/UserRepository.java
+++ b/src/main/java/com/feelmycode/parabole/repository/UserRepository.java
@@ -1,9 +1,7 @@
 package com.feelmycode.parabole.repository;
 
 import com.feelmycode.parabole.domain.User;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 

--- a/src/main/java/com/feelmycode/parabole/service/UserService.java
+++ b/src/main/java/com/feelmycode/parabole/service/UserService.java
@@ -61,8 +61,7 @@ public class UserService {
         }
         if (user.getSeller() == null)
             return 1;       // USER
-        else
-            return 2;       // SELLER
+        return 2;       // SELLER
     }
 
     @Transactional


### PR DESCRIPTION
## 개요
 jpa 적용 중 User, Seller Entity 공동 수정 작업

## 작업한 내용
UserController 49line
이 부분이 email로 처리되어있는데  userId로 바꿔서 처리하고 메서드 명, 변수 바꾸기
int checkAccountRole(email) -> boolean isUser(userId)로 변경 

UserController 59line
mypageuserinfo-> getUserInfo 이름을 직관적으로 바꾸기

userRepository에서 안쓰는 import 지우기

UserService에서 
@transactional(readOnly = true)를 @RequiredArgsConstructor아래로 바꾸고 readOnly=true를 사용하는 부분 지우기

user정보를 가져오는 방식을 findbyId로 바꾸고 매개변수 userid로 바꾸고 User정보를 가져오는 부분만 따로 메서드로 빼서 user를 가져올 때 호출하기 (함수 리팩토링)

!SellerRepository에서 storeName으로 Seller가져오는 코드 추가하기

@PostMapping() -> @PostMapping

결과하여
49 line - checkAccountRole API 문서도 수정해 주어야함


## 리뷰 가이드 

## 테스트 결과

## 앞으로 추가 예정 내용

## 기타 내용

## 이슈번호
