### PR TITLE
[Feature/event-searchOptions] 이벤트 응모내역 및 이벤트 검색조건 조회 구현

### DIFF
--- a/src/main/java/com/feelmycode/parabole/controller/EventApplyController.java
+++ b/src/main/java/com/feelmycode/parabole/controller/EventApplyController.java
@@ -1,6 +1,7 @@
 package com.feelmycode.parabole.controller;
 
 import com.feelmycode.parabole.dto.EventApplyDto;
+import com.feelmycode.parabole.dto.EventParticipantDto;
 import com.feelmycode.parabole.dto.RequestEventApplyCheckDto;
 import com.feelmycode.parabole.global.api.ParaboleResponse;
 import com.feelmycode.parabole.service.EventParticipantService;
@@ -8,10 +9,13 @@ import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/event")
@@ -34,5 +38,11 @@ public class EventApplyController {
         }
         return ParaboleResponse.CommonResponse(HttpStatus.OK, true,
             dto.getEventId() + "번 이벤트에 응모한적이 없습니다", true);
+    }
+
+    @GetMapping("/seller/participant/{eventId}")
+    public ResponseEntity<ParaboleResponse> getEventParticipants(@PathVariable Long eventId) {
+        List<EventParticipantDto> response = eventParticipantService.getEventParticipants(eventId);
+        return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "이벤트 응모 리스트 조회 성공", response);
     }
 }

--- a/src/main/java/com/feelmycode/parabole/controller/EventController.java
+++ b/src/main/java/com/feelmycode/parabole/controller/EventController.java
@@ -2,6 +2,8 @@ package com.feelmycode.parabole.controller;
 
 import com.feelmycode.parabole.dto.EventCreateRequestDto;
 import com.feelmycode.parabole.dto.EventListResponseDto;
+import com.feelmycode.parabole.dto.EventSearchRequestDto;
+import com.feelmycode.parabole.dto.EventSearchResponseDto;
 import com.feelmycode.parabole.global.api.ParaboleResponse;
 import com.feelmycode.parabole.global.error.exception.ParaboleException;
 import com.feelmycode.parabole.service.EventService;
@@ -49,6 +51,12 @@ public class EventController {
     public ResponseEntity<ParaboleResponse> getEvent() {
         List<EventListResponseDto> response = eventService.getEventListResponseDto(eventService.getEventsAllNotDeleted());
         return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "이벤트 리스트 조회 성공", response);
+    }
+
+    @GetMapping("/list")
+    public ResponseEntity<ParaboleResponse> getEventList(@RequestBody EventSearchRequestDto eventSearchRequestDto) {
+        List<EventSearchResponseDto> response = eventService.getEventsSearch(eventSearchRequestDto);
+        return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "이벤트 검색 리스트 조회 성공", response);
     }
 
     @GetMapping("/seller/{userId}")

--- a/src/main/java/com/feelmycode/parabole/dto/EventParticipantDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/EventParticipantDto.java
@@ -1,0 +1,28 @@
+package com.feelmycode.parabole.dto;
+
+import com.feelmycode.parabole.domain.Event;
+import com.feelmycode.parabole.domain.EventParticipant;
+import com.feelmycode.parabole.domain.User;
+import java.time.LocalDateTime;
+
+public class EventParticipantDto {
+
+    private Long id;
+    private UserDto user;
+    private LocalDateTime eventTimeStartAt;
+
+    public EventParticipantDto(EventParticipant eventParticipant) {
+        id = eventParticipant.getId();
+        user = new UserDto(eventParticipant.getUser());
+        eventTimeStartAt = eventParticipant.getEventTimeStartAt();
+    }
+
+    @Override
+    public String toString() {
+        return "EventParticipantDto{" +
+            "id=" + id +
+            ", user=" + user.getName() +
+            ", eventTimeStartAt=" + eventTimeStartAt +
+            '}';
+    }
+}

--- a/src/main/java/com/feelmycode/parabole/dto/EventParticipantDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/EventParticipantDto.java
@@ -4,7 +4,9 @@ import com.feelmycode.parabole.domain.Event;
 import com.feelmycode.parabole.domain.EventParticipant;
 import com.feelmycode.parabole.domain.User;
 import java.time.LocalDateTime;
+import lombok.Getter;
 
+@Getter
 public class EventParticipantDto {
 
     private Long id;
@@ -17,12 +19,4 @@ public class EventParticipantDto {
         eventTimeStartAt = eventParticipant.getEventTimeStartAt();
     }
 
-    @Override
-    public String toString() {
-        return "EventParticipantDto{" +
-            "id=" + id +
-            ", user=" + user.getName() +
-            ", eventTimeStartAt=" + eventTimeStartAt +
-            '}';
-    }
 }

--- a/src/main/java/com/feelmycode/parabole/dto/EventSearchRequestDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/EventSearchRequestDto.java
@@ -1,0 +1,18 @@
+package com.feelmycode.parabole.dto;
+
+import com.feelmycode.parabole.enumtype.EventStatus;
+import com.feelmycode.parabole.enumtype.EventType;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class EventSearchRequestDto {
+
+    private EventType eventType;
+    private String eventTitle;
+    private Integer dateDiv;
+    private LocalDateTime fromDateTime;
+    private LocalDateTime toDateTime;
+    private EventStatus eventStatus;
+
+}

--- a/src/main/java/com/feelmycode/parabole/dto/EventSearchResponseDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/EventSearchResponseDto.java
@@ -1,0 +1,38 @@
+package com.feelmycode.parabole.dto;
+
+import com.feelmycode.parabole.domain.Event;
+import com.feelmycode.parabole.domain.EventImage;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class EventSearchResponseDto {
+
+    private Long id;
+    private Long sellerId;
+    private String createdBy;
+    private String type;
+    private String title;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+    private Integer status;
+    private String descript;
+    private EventImage eventImage;
+
+    public EventSearchResponseDto(Event event) {
+        id = event.getId();
+        sellerId = event.getSeller().getId();
+        createdBy = event.getCreatedBy();
+        type = event.getType();
+        title = event.getTitle();
+        startAt = event.getStartAt();
+        endAt = event.getEndAt();
+        status = event.getStatus();
+        descript = event.getDescript();
+        eventImage = event.getEventImage();
+    }
+}

--- a/src/main/java/com/feelmycode/parabole/dto/UserDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/UserDto.java
@@ -11,7 +11,6 @@ public class UserDto {
     private String name;
     private String nickname;
     private String phone;
-    private String password;
 
     public UserDto(User user) {
         id = user.getId();
@@ -19,6 +18,5 @@ public class UserDto {
         name = user.getName();
         nickname = user.getNickname();
         phone = user.getPhone();
-        password = user.getPassword();
     }
 }

--- a/src/main/java/com/feelmycode/parabole/dto/UserDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/UserDto.java
@@ -1,0 +1,24 @@
+package com.feelmycode.parabole.dto;
+
+import com.feelmycode.parabole.domain.User;
+import lombok.Getter;
+
+@Getter
+public class UserDto {
+
+    private Long id;
+    private String email;
+    private String name;
+    private String nickname;
+    private String phone;
+    private String password;
+
+    public UserDto(User user) {
+        id = user.getId();
+        email = user.getEmail();
+        name = user.getName();
+        nickname = user.getNickname();
+        phone = user.getPhone();
+        password = user.getPassword();
+    }
+}

--- a/src/main/java/com/feelmycode/parabole/enumtype/EventStatus.java
+++ b/src/main/java/com/feelmycode/parabole/enumtype/EventStatus.java
@@ -1,0 +1,27 @@
+package com.feelmycode.parabole.enumtype;
+
+import java.util.Arrays;
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+public enum EventStatus {
+    BEFORE("BEFORE", "진행전", 0),
+    INPROGRESS("INPROGRESS", "진행중", 1),
+    END("END", "종료", 2);
+
+    private String code;
+    private String name;
+    private Integer value;
+
+    EventStatus(String code, String name, Integer value) {
+        this.code = code;
+        this.name = name;
+        this.value = value;
+    }
+
+    public static boolean isUpdatable(Integer value) {
+        return value == 0 ? true: false;
+    }
+
+}

--- a/src/main/java/com/feelmycode/parabole/enumtype/EventType.java
+++ b/src/main/java/com/feelmycode/parabole/enumtype/EventType.java
@@ -1,0 +1,20 @@
+package com.feelmycode.parabole.enumtype;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+public enum EventType {
+    RAFFLE("RAFFLE","추첨", 1),
+    FCFS("FCFS","선착순", 2);
+
+    private String code;
+    private String name;
+    private Integer value;
+
+    EventType(String code, String name, Integer value) {
+        this.code = code;
+        this.name = name;
+        this.value = value;
+    }
+}

--- a/src/main/java/com/feelmycode/parabole/repository/EventParticipantRepository.java
+++ b/src/main/java/com/feelmycode/parabole/repository/EventParticipantRepository.java
@@ -2,8 +2,10 @@ package com.feelmycode.parabole.repository;
 
 import com.feelmycode.parabole.domain.EventParticipant;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
 public interface EventParticipantRepository extends JpaRepository<EventParticipant, Long> {
 
     EventParticipant findByUserIdAndEventId(Long userId, Long eventId);
+    List<EventParticipant> findAllByEventId(Long eventId);
 }

--- a/src/main/java/com/feelmycode/parabole/repository/EventRepository.java
+++ b/src/main/java/com/feelmycode/parabole/repository/EventRepository.java
@@ -2,6 +2,9 @@ package com.feelmycode.parabole.repository;
 
 import com.feelmycode.parabole.domain.Event;
 import com.feelmycode.parabole.domain.Seller;
+import com.feelmycode.parabole.enumtype.EventStatus;
+import com.feelmycode.parabole.enumtype.EventType;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -12,5 +15,9 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     List<Event> findAllByIsDeleted(boolean isDeleted);
     List<Event> findAllBySellerAndIsDeleted(Seller seller, boolean isDeleted);
     List<Event> findAllBySellerIdOrderByStartAtAsc(Long SellerId);
-
+    List<Event> findAllByTypeAndIsDeleted(String eventType, boolean isDeleted);
+    List<Event> findAllByTitleContainingAndIsDeleted(String eventTitle, boolean isDeleted);
+    List<Event> findAllByStartAtBetweenAndIsDeleted(LocalDateTime startDateTime, LocalDateTime endDateTime, boolean isDeleted);
+    List<Event> findAllByEndAtBetweenAndIsDeleted(LocalDateTime startDateTime, LocalDateTime endDateTime, boolean isDeleted);
+    List<Event> findAllByStatusAndIsDeleted(Integer eventStatus, boolean isDeleted);
 }

--- a/src/main/java/com/feelmycode/parabole/service/EventParticipantService.java
+++ b/src/main/java/com/feelmycode/parabole/service/EventParticipantService.java
@@ -5,6 +5,7 @@ import com.feelmycode.parabole.domain.EventParticipant;
 import com.feelmycode.parabole.domain.EventPrize;
 import com.feelmycode.parabole.domain.User;
 import com.feelmycode.parabole.dto.EventApplyDto;
+import com.feelmycode.parabole.dto.EventParticipantDto;
 import com.feelmycode.parabole.dto.RequestEventApplyCheckDto;
 import com.feelmycode.parabole.global.error.exception.ParaboleException;
 import com.feelmycode.parabole.repository.EventParticipantRepository;
@@ -12,6 +13,8 @@ import com.feelmycode.parabole.repository.EventPrizeRepository;
 import com.feelmycode.parabole.repository.EventRepository;
 import com.feelmycode.parabole.repository.UserRepository;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -43,6 +46,14 @@ public class EventParticipantService {
             return false;
         }
         return true;
+    }
+
+    public List<EventParticipantDto> getEventParticipants(Long eventId) {
+        List<EventParticipant> eventParticipantList = eventParticipantRepository.findAllByEventId(eventId);
+
+        return eventParticipantList.stream()
+            .map(EventParticipantDto::new)
+            .collect(Collectors.toList());
     }
 
     private void applyCheck(EventApplyDto eventApplyDto) {

--- a/src/main/java/com/feelmycode/parabole/service/EventService.java
+++ b/src/main/java/com/feelmycode/parabole/service/EventService.java
@@ -8,11 +8,16 @@ import com.feelmycode.parabole.domain.Seller;
 import com.feelmycode.parabole.dto.EventCreateRequestDto;
 import com.feelmycode.parabole.dto.EventListResponseDto;
 import com.feelmycode.parabole.dto.EventPrizeCreateRequestDto;
+import com.feelmycode.parabole.dto.EventSearchRequestDto;
+import com.feelmycode.parabole.dto.EventSearchResponseDto;
+import com.feelmycode.parabole.enumtype.EventStatus;
+import com.feelmycode.parabole.enumtype.EventType;
 import com.feelmycode.parabole.global.error.exception.ParaboleException;
 import com.feelmycode.parabole.repository.CouponRepository;
 import com.feelmycode.parabole.repository.EventRepository;
 import com.feelmycode.parabole.repository.ProductRepository;
 import com.feelmycode.parabole.repository.SellerRepository;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -21,6 +26,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
 @Service
 @Transactional(readOnly = true)
@@ -115,6 +121,28 @@ public class EventService {
     public List<Event> getEventsBySellerId(Long userId) {
         Seller seller = sellerService.getSellerByUserId(userId);
         return eventRepository.findAllBySellerAndIsDeleted(seller, false);
+    }
+
+    /**
+     * 검색 조건으로 이벤트 목록 조회 (경품 목록 제외)
+     */
+    public List<EventSearchResponseDto> getEventsSearch(EventSearchRequestDto eventSearchRequestDto) {
+
+        List<Event> eventList = null;
+        if(!StringUtils.isEmpty(eventSearchRequestDto.getEventType())) {
+            eventList = eventRepository.findAllByTypeAndIsDeleted(eventSearchRequestDto.getEventType().getCode(), false);
+        } else if (!StringUtils.isEmpty(eventSearchRequestDto.getEventTitle())) {
+            eventList = eventRepository.findAllByTitleContainingAndIsDeleted(eventSearchRequestDto.getEventTitle(), false);
+        } else if (!StringUtils.isEmpty(eventSearchRequestDto.getDateDiv())) {
+            eventList = eventSearchRequestDto.getDateDiv() < 1 ?
+                eventRepository.findAllByStartAtBetweenAndIsDeleted(eventSearchRequestDto.getFromDateTime(), eventSearchRequestDto.getToDateTime(), false) : eventRepository.findAllByEndAtBetweenAndIsDeleted(eventSearchRequestDto.getFromDateTime(), eventSearchRequestDto.getToDateTime(), false);
+        } else if (!StringUtils.isEmpty(eventSearchRequestDto.getEventStatus())) {
+            eventList = eventRepository.findAllByStatusAndIsDeleted(eventSearchRequestDto.getEventStatus().getValue(), false);
+        }
+
+        return eventList.stream()
+            .map(EventSearchResponseDto::new)
+            .collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/com/feelmycode/parabole/service/EventService.java
+++ b/src/main/java/com/feelmycode/parabole/service/EventService.java
@@ -134,8 +134,9 @@ public class EventService {
         } else if (!StringUtils.isEmpty(eventSearchRequestDto.getEventTitle())) {
             eventList = eventRepository.findAllByTitleContainingAndIsDeleted(eventSearchRequestDto.getEventTitle(), false);
         } else if (!StringUtils.isEmpty(eventSearchRequestDto.getDateDiv())) {
-            eventList = eventSearchRequestDto.getDateDiv() < 1 ?
-                eventRepository.findAllByStartAtBetweenAndIsDeleted(eventSearchRequestDto.getFromDateTime(), eventSearchRequestDto.getToDateTime(), false) : eventRepository.findAllByEndAtBetweenAndIsDeleted(eventSearchRequestDto.getFromDateTime(), eventSearchRequestDto.getToDateTime(), false);
+            eventList = eventSearchRequestDto.getDateDiv() < 1 
+            ? eventRepository.findAllByStartAtBetweenAndIsDeleted(eventSearchRequestDto.getFromDateTime(), eventSearchRequestDto.getToDateTime(), false) 
+            : eventRepository.findAllByEndAtBetweenAndIsDeleted(eventSearchRequestDto.getFromDateTime(), eventSearchRequestDto.getToDateTime(), false);
         } else if (!StringUtils.isEmpty(eventSearchRequestDto.getEventStatus())) {
             eventList = eventRepository.findAllByStatusAndIsDeleted(eventSearchRequestDto.getEventStatus().getValue(), false);
         }


### PR DESCRIPTION
## 개요
판매자 화면에서 특정 이벤트에 대한 사용자들의 응모내역 확인할 수 있는 API구현
이벤트 목록에서 검색 조건으로 조회할 있는 API구현

## 작업한 내용
- 이벤트 응모내역 API 구현
- 검색조건(이벤트 타입, 제목, 날짜, 이벤트 진행상태)으로 조회할 수 있는 API구현
- 이벤트 타입과 상태 Enum클래스 구현

## 테스트 결과
![image](https://user-images.githubusercontent.com/37797830/195740140-6c703a07-79e9-43c0-b3bd-80d0b61dec95.png)
![image](https://user-images.githubusercontent.com/37797830/195740171-3f01eb3e-8144-42f0-ac92-496a8f721726.png)

![image](https://user-images.githubusercontent.com/37797830/195740290-a5ac7fd8-527f-4357-9be9-edd776cf797c.png)
![image](https://user-images.githubusercontent.com/37797830/195740423-aa042c58-ffe5-477f-b2d8-b71280a0f287.png)

## 앞으로 추가할 내용
- 컨트롤러에서 DTO로 변환해 서비스로 넘기는 기존 API 리팩토링
- Enum적용안된 기존코드 리팩토링
-
## 이슈번호
[#128]
