### PR TITLE
[feature/cart_controller]Fix: 장바구니 삭제 메서드 수정

### DIFF
--- a/src/main/java/com/feelmycode/parabole/controller/CartController.java
+++ b/src/main/java/com/feelmycode/parabole/controller/CartController.java
@@ -39,8 +39,8 @@ public class CartController {
 
     @DeleteMapping(value = "/delete")
     public ResponseEntity<ParaboleResponse> deleteProductInCart(
-        @RequestBody CartItemDeleteRequestDto dto) {
-        cartItemService.cartListDelete(dto);
+        @RequestParam Long userId, @RequestParam Long cartItemId) {
+        cartItemService.cartListDelete(new CartItemDeleteRequestDto(userId, cartItemId));
         return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "장바구니 상품 삭제");
 
     }

--- a/src/main/java/com/feelmycode/parabole/dto/CartItemDeleteRequestDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/CartItemDeleteRequestDto.java
@@ -1,6 +1,5 @@
 package com.feelmycode.parabole.dto;
 
-import java.util.List;
 import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,9 +12,9 @@ public class CartItemDeleteRequestDto {
     private Long userId;
 
     @NotNull
-    private List<Long> cartItemId;
+    private Long cartItemId;
 
-    public CartItemDeleteRequestDto(Long userId, List<Long> cartItemId) {
+    public CartItemDeleteRequestDto(Long userId, Long cartItemId) {
         this.userId = userId;
         this.cartItemId = cartItemId;
     }

--- a/src/main/java/com/feelmycode/parabole/repository/CartItemRepository.java
+++ b/src/main/java/com/feelmycode/parabole/repository/CartItemRepository.java
@@ -4,8 +4,6 @@ import com.feelmycode.parabole.domain.CartItem;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-
 
 public interface CartItemRepository extends JpaRepository<CartItem, Long> {
 
@@ -13,8 +11,5 @@ public interface CartItemRepository extends JpaRepository<CartItem, Long> {
     Optional<CartItem> findById(Long cartItemId);
     Optional<CartItem> findByCartIdAndProductId(Long cartId, Long productId);
     Long countByCartId(Long cartId);
-
-    @Modifying
-    void deleteAllByIdIn(List<Long> cartItemId);
 
 }

--- a/src/main/java/com/feelmycode/parabole/service/CartItemService.java
+++ b/src/main/java/com/feelmycode/parabole/service/CartItemService.java
@@ -10,7 +10,6 @@ import com.feelmycode.parabole.dto.CartItemGetResponseDto;
 import com.feelmycode.parabole.dto.CartItemUpdateRequestDto;
 import com.feelmycode.parabole.global.error.exception.ParaboleException;
 import com.feelmycode.parabole.repository.CartItemRepository;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import org.springframework.transaction.annotation.Transactional;
@@ -78,21 +77,12 @@ public class CartItemService {
 
     @Transactional
     public void cartListDelete(CartItemDeleteRequestDto cartItemRequestDto) {
-        cartItemRepository.deleteAllByIdIn(getCartItemId(cartItemRequestDto));
+        cartItemRepository.deleteById(cartItemRequestDto.getCartItemId());
     }
 
     private CartItem getCartItem(Long cartItemId) {
         return cartItemRepository.findById(cartItemId)
             .orElseThrow(() -> new ParaboleException(HttpStatus.BAD_REQUEST, "장바구니에 상품이 존재하지 않습니다."));
-    }
-
-    private List<Long> getCartItemId(CartItemDeleteRequestDto cartItemRequestDto) {
-        List<Long> result = new ArrayList<>();
-        for (Long cid : cartItemRequestDto.getCartItemId()) {
-            cartItemRepository.findById(cid).orElseThrow(() -> new ParaboleException(HttpStatus.BAD_REQUEST, "해당 상품 장바구니가 존재하지 않습니다"));
-            result.add(cid);
-        }
-        return result;
     }
 
 }


### PR DESCRIPTION
## 개요
restful api에서 delete 메서드는 request param으로 받아야 한다

## 작업한 내용
장바구니 삭제 메서드 수정

## 기타사항

postman에서는 dto 전송했을때 정상 동작했는데 

프런트에서 똑같이 작업했을때는 오류가 나더라구요

구글링 해보니 delete 메서드는 param으로 보내야 한다고 합니다.

수정했으니 확인부탁드립니다~!