### PR TITLE
[Feat/eventapplyinfo] 사용자 이벤트 상세페이지 BE 구현

### DIFF
--- a/src/main/java/com/feelmycode/parabole/controller/EventApplyController.java
+++ b/src/main/java/com/feelmycode/parabole/controller/EventApplyController.java
@@ -2,6 +2,7 @@ package com.feelmycode.parabole.controller;
 
 import com.feelmycode.parabole.dto.EventApplyDto;
 import com.feelmycode.parabole.dto.EventParticipantDto;
+import com.feelmycode.parabole.dto.EventParticipantUserDto;
 import com.feelmycode.parabole.dto.RequestEventApplyCheckDto;
 import com.feelmycode.parabole.global.api.ParaboleResponse;
 import com.feelmycode.parabole.service.EventParticipantService;
@@ -45,4 +46,11 @@ public class EventApplyController {
         List<EventParticipantDto> response = eventParticipantService.getEventParticipants(eventId);
         return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "이벤트 응모 리스트 조회 성공", response);
     }
+
+    @GetMapping("/user/participant/{userId}")
+    public ResponseEntity<ParaboleResponse> getUserEventParticipants(@PathVariable Long userId) {
+        List<EventParticipantUserDto> response = eventParticipantService.getEventParticipantUser(userId);
+        return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "유저 이벤트 응모 리스트 조회 성공", response);
+    }
+
 }

--- a/src/main/java/com/feelmycode/parabole/dto/EventDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/EventDto.java
@@ -16,48 +16,58 @@ import lombok.NoArgsConstructor;
 @Getter
 public class EventDto {
 
-  private Long id;
-  private Seller seller;
-  private String createdBy;
-  private String type;
-  private String title;
-  private LocalDateTime startAt;
-  private LocalDateTime endAt;
-  private Integer status;
-  private String descript;
-  private EventImage eventImage;
-  private List<EventPrize> eventPrizes;
+    private Long id;
+    private Seller seller;
+    private String createdBy;
+    private String type;
+    private String title;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+    private Integer status;
+    private String descript;
+    private EventImage eventImage;
+    private List<EventPrize> eventPrizes;
 
-  public EventDto(Long id, Seller seller, String createdBy, String type, String title,
-      LocalDateTime startAt, LocalDateTime endAt, Integer status, String descript,
-      EventImage eventImage, List<EventPrize> eventPrizes) {
-    this.id = id;
-    this.seller = seller;
-    this.createdBy = createdBy;
-    this.type = type;
-    this.title = title;
-    this.startAt = startAt;
-    this.endAt = endAt;
-    this.status = status;
-    this.descript = descript;
-    this.eventImage = eventImage;
-    this.eventPrizes = eventPrizes;
-  }
+    public EventDto(Long id, Seller seller, String createdBy, String type, String title,
+        LocalDateTime startAt, LocalDateTime endAt, Integer status, String descript,
+        EventImage eventImage, List<EventPrize> eventPrizes) {
+        this.id = id;
+        this.seller = seller;
+        this.createdBy = createdBy;
+        this.type = type;
+        this.title = title;
+        this.startAt = startAt;
+        this.endAt = endAt;
+        this.status = status;
+        this.descript = descript;
+        this.eventImage = eventImage;
+        this.eventPrizes = eventPrizes;
+    }
 
-  static public EventDto of(Event event) {
-    return EventDto.builder()
-        .id(event.getId())
-        .seller(event.getSeller())
-        .createdBy(event.getCreatedBy())
-        .type(event.getType())
-        .title(event.getTitle())
-        .startAt(event.getStartAt())
-        .endAt(event.getEndAt())
-        .status(event.getStatus())
-        .descript(event.getDescript())
-        .eventImage(event.getEventImage())
-        .eventPrizes(event.getEventPrizes())
-        .build();
-  }
+    public EventDto(Long id, String title, LocalDateTime startAt, LocalDateTime endAt,
+        Integer status, EventImage eventImage) {
+        this.id = id;
+        this.title = title;
+        this.startAt = startAt;
+        this.endAt = endAt;
+        this.status = status;
+        this.eventImage = eventImage;
+    }
+
+    static public EventDto of(Event event) {
+        return EventDto.builder()
+            .id(event.getId())
+            .seller(event.getSeller())
+            .createdBy(event.getCreatedBy())
+            .type(event.getType())
+            .title(event.getTitle())
+            .startAt(event.getStartAt())
+            .endAt(event.getEndAt())
+            .status(event.getStatus())
+            .descript(event.getDescript())
+            .eventImage(event.getEventImage())
+            .eventPrizes(event.getEventPrizes())
+            .build();
+    }
 
 }

--- a/src/main/java/com/feelmycode/parabole/dto/EventParticipantUserDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/EventParticipantUserDto.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class EventParticipantUserDto {
+
     private Long userId;
     private Long eventId;
 
@@ -19,15 +20,15 @@ public class EventParticipantUserDto {
     private Integer status;
     private String eventImg;
 
-    public EventParticipantUserDto(EventParticipant eventParticipant){
-        Event event=eventParticipant.getEvent();
-        this.userId=eventParticipant.getUser().getId();
+    public EventParticipantUserDto(EventParticipant eventParticipant) {
+        Event event = eventParticipant.getEvent();
+        this.userId = eventParticipant.getUser().getId();
         this.eventId = event.getId();
-        this.eventTimeStartAt=eventParticipant.getEventTimeStartAt();
+        this.eventTimeStartAt = eventParticipant.getEventTimeStartAt();
         this.eventTitle = event.getTitle();
         this.startAt = event.getStartAt();
         this.endAt = event.getEndAt();
         this.status = event.getStatus();
-        this.eventImg=event.getEventImage().getEventBannerImg();
+        this.eventImg = event.getEventImage().getEventBannerImg();
     }
 }

--- a/src/main/java/com/feelmycode/parabole/dto/EventParticipantUserDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/EventParticipantUserDto.java
@@ -1,0 +1,33 @@
+package com.feelmycode.parabole.dto;
+
+import com.feelmycode.parabole.domain.Event;
+import com.feelmycode.parabole.domain.EventParticipant;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EventParticipantUserDto {
+    private Long userId;
+    private Long eventId;
+
+    private LocalDateTime eventTimeStartAt;
+    private String eventTitle;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+    private Integer status;
+    private String eventImg;
+
+    public EventParticipantUserDto(EventParticipant eventParticipant){
+        Event event=eventParticipant.getEvent();
+        this.userId=eventParticipant.getUser().getId();
+        this.eventId = event.getId();
+        this.eventTimeStartAt=eventParticipant.getEventTimeStartAt();
+        this.eventTitle = event.getTitle();
+        this.startAt = event.getStartAt();
+        this.endAt = event.getEndAt();
+        this.status = event.getStatus();
+        this.eventImg=event.getEventImage().getEventBannerImg();
+    }
+}

--- a/src/main/java/com/feelmycode/parabole/dto/EventPrizeDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/EventPrizeDto.java
@@ -30,7 +30,7 @@ public class EventPrizeDto {
             Coupon coupon = eventPrize.getCoupon();
             couponId = coupon.getId();
             couponDetail = coupon.getDetail();
-            couponDiscountRate = coupon.getDiscountRate();
+            couponDiscountRate = coupon.getDiscountValue();
             this.stock = eventPrize.getStock();
             this.expiresAt = coupon.getExpiresAt();
         } else if (this.prizeType.equals("PRODUCT")) {

--- a/src/main/java/com/feelmycode/parabole/dto/EventPrizeDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/EventPrizeDto.java
@@ -19,7 +19,7 @@ public class EventPrizeDto {
     private String productImg;
     private Long couponId;
     private String couponDetail;
-    private Integer couponDiscountRate;
+    private Integer couponDiscountValue;
     private LocalDateTime expiresAt;
 
     public EventPrizeDto(EventPrize eventPrize) {
@@ -30,7 +30,7 @@ public class EventPrizeDto {
             Coupon coupon = eventPrize.getCoupon();
             couponId = coupon.getId();
             couponDetail = coupon.getDetail();
-            couponDiscountRate = coupon.getDiscountValue();
+            couponDiscountValue = coupon.getDiscountValue();
             this.stock = eventPrize.getStock();
             this.expiresAt = coupon.getExpiresAt();
         } else if (this.prizeType.equals("PRODUCT")) {

--- a/src/main/java/com/feelmycode/parabole/repository/EventParticipantRepository.java
+++ b/src/main/java/com/feelmycode/parabole/repository/EventParticipantRepository.java
@@ -8,4 +8,5 @@ public interface EventParticipantRepository extends JpaRepository<EventParticipa
 
     EventParticipant findByUserIdAndEventId(Long userId, Long eventId);
     List<EventParticipant> findAllByEventId(Long eventId);
+    List<EventParticipant> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/feelmycode/parabole/service/EventParticipantService.java
+++ b/src/main/java/com/feelmycode/parabole/service/EventParticipantService.java
@@ -6,6 +6,7 @@ import com.feelmycode.parabole.domain.EventPrize;
 import com.feelmycode.parabole.domain.User;
 import com.feelmycode.parabole.dto.EventApplyDto;
 import com.feelmycode.parabole.dto.EventParticipantDto;
+import com.feelmycode.parabole.dto.EventParticipantUserDto;
 import com.feelmycode.parabole.dto.RequestEventApplyCheckDto;
 import com.feelmycode.parabole.global.error.exception.ParaboleException;
 import com.feelmycode.parabole.repository.EventParticipantRepository;
@@ -27,6 +28,16 @@ public class EventParticipantService {
     private final UserRepository userRepository;
     private final EventPrizeRepository eventPrizeRepository;
     private final EventRepository eventRepository;
+
+    public List<EventParticipantUserDto> getEventParticipantUser(Long userId) {
+        List<EventParticipant> eventParticipant = eventParticipantRepository.findAllByUserId(getUser(userId).getId());
+
+        if (eventParticipant == null) {
+            throw new ParaboleException(HttpStatus.NOT_FOUND, "이벤트 참여내역이 없습니다.");
+        }
+        return eventParticipant.stream().map(EventParticipantUserDto::new)
+            .collect(Collectors.toList());
+    }
 
     public void eventJoin(EventApplyDto eventApplyDto) {
         applyCheck(eventApplyDto);


### PR DESCRIPTION


## 개요
사용자 이벤트 상세 api 구현

## 작업한 내용
이벤트 상세페이지 백엔드 구현
## 리뷰 가이드 
기존 이벤트 응모 내역만 조회할까 하다가 응모 시간도 추가함
## 테스트 결과
![image](https://user-images.githubusercontent.com/69442251/196056661-91855a69-6fdf-4fe8-bf4f-ba3d667bcee4.png)


## 앞으로 추가 예정 내용
api 설계문서에 추가

## 이슈번호
#136 

