### PR TITLE
[Fix/seller-event] 이벤트 응모 리스트 반환 dto 수정

### DIFF
--- a/src/main/java/com/feelmycode/parabole/dto/EventParticipantDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/EventParticipantDto.java
@@ -1,9 +1,8 @@
 package com.feelmycode.parabole.dto;
 
-import com.feelmycode.parabole.domain.Event;
 import com.feelmycode.parabole.domain.EventParticipant;
-import com.feelmycode.parabole.domain.User;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.Getter;
 
 @Getter
@@ -11,11 +10,13 @@ public class EventParticipantDto {
 
     private Long id;
     private UserDto user;
+    private List<EventPrizeDto> eventPrizes;
     private LocalDateTime eventTimeStartAt;
 
     public EventParticipantDto(EventParticipant eventParticipant) {
         id = eventParticipant.getId();
         user = new UserDto(eventParticipant.getUser());
+        eventPrizes = eventParticipant.getEvent().getEventPrizes().stream().map(EventPrizeDto::new).toList();
         eventTimeStartAt = eventParticipant.getEventTimeStartAt();
     }
 


### PR DESCRIPTION
## 개요
특정 이벤트에 응모한 사용자 리스트를 보는 API에 경품 정보가 부족해서 반환 DTO를 수정

## 작업한 내용
- EventParticipantDto에 EventPrizeDto 반환값 수정

## 리뷰 가이드 
필요한 데이터가 잘 전달되는지 봐주세요

## 테스트 결과
![image](https://user-images.githubusercontent.com/37797830/196067295-07d3bae5-29cd-40aa-a095-ad0d793b1b79.png)

