### PR TITLE
[feature/order] 장바구니에서 주문에 일시적으로 저장한 후 주문할 수 있게 수정

### DIFF
--- a/src/main/java/com/feelmycode/parabole/controller/OrderController.java
+++ b/src/main/java/com/feelmycode/parabole/controller/OrderController.java
@@ -1,15 +1,16 @@
 package com.feelmycode.parabole.controller;
 
 import com.feelmycode.parabole.domain.Order;
+import com.feelmycode.parabole.dto.OrderUpdateRequestDto;
 import com.feelmycode.parabole.global.api.ParaboleResponse;
-import com.feelmycode.parabole.global.error.exception.ParaboleException;
+import com.feelmycode.parabole.service.OrderInfoService;
 import com.feelmycode.parabole.service.OrderService;
 import com.feelmycode.parabole.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,23 +27,19 @@ public class OrderController {
 
     private final OrderService orderService;
     private final UserService userService;
+    private final OrderInfoService orderInfoService;
 
-    @PostMapping
-    public ResponseEntity<ParaboleResponse> createOrder(@RequestBody Long userId) {
+    @GetMapping
+    public ResponseEntity<ParaboleResponse> createOrder(@RequestParam Long userId) {
         log.info("Create Order. userId: {}", userId);
         orderService.createOrder(new Order(userService.getUser(userId), DELIVERY_FEE));
         return ParaboleResponse.CommonResponse(HttpStatus.CREATED, true, "주문 정보 생성 완료");
     }
 
-    @DeleteMapping
-    public ResponseEntity<ParaboleResponse> orderCancel(@RequestParam Long orderId) {
-        log.info("Delete Order. userId: {}, orderId: {}", orderId);
-        try {
-            orderService.deleteOrder(orderId);
-        } catch (Exception e) {
-            throw new ParaboleException(HttpStatus.BAD_REQUEST, "주문을 취소할 수 없습니다.");
-        }
-        return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "주문을 취소했습니다.");
+    @PostMapping("/update")
+    public ResponseEntity<ParaboleResponse> updateOrder(@RequestBody OrderUpdateRequestDto orderUpdateRequestDto) {
+        orderService.updateOrderState(orderUpdateRequestDto);
+        return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "주문 수정 완료");
     }
 
 }

--- a/src/main/java/com/feelmycode/parabole/controller/OrderController.java
+++ b/src/main/java/com/feelmycode/parabole/controller/OrderController.java
@@ -1,23 +1,17 @@
 package com.feelmycode.parabole.controller;
 
-import com.feelmycode.parabole.domain.Order;
 import com.feelmycode.parabole.dto.OrderDeliveryUpdateRequestDto;
 import com.feelmycode.parabole.dto.OrderUpdateRequestDto;
-import com.feelmycode.parabole.enumtype.OrderInfoState;
 import com.feelmycode.parabole.global.api.ParaboleResponse;
-import com.feelmycode.parabole.service.OrderInfoService;
-import com.feelmycode.parabole.service.OrderService;
-import com.feelmycode.parabole.service.UserService;
+import com.feelmycode.parabole.service.UpdateService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -26,21 +20,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class OrderController {
 
-    private static final Long DELIVERY_FEE = 0L;
-
-    private final OrderService orderService;
-    private final OrderInfoService orderInfoService;
+    private final UpdateService updateService;
 
     @PostMapping
     public ResponseEntity<ParaboleResponse> updateOrder(@RequestBody OrderUpdateRequestDto orderUpdateRequestDto) {
-        orderService.updateOrderState(orderUpdateRequestDto);
+
+        updateService.updateOrderState(orderUpdateRequestDto);
         return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "주문 수정 완료");
     }
 
     @PatchMapping
     public ResponseEntity<ParaboleResponse> updateDelivery(@RequestBody OrderDeliveryUpdateRequestDto updateDto) {
-        orderService.updateDeliveryInfo(updateDto);
-        orderInfoService.updateOrderInfoState(updateDto.getUserId(), updateDto.getOrderInfoState());
+        updateService.updateDeliveryInfo(updateDto);
         return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "주문 정보 저장 완료");
     }
 

--- a/src/main/java/com/feelmycode/parabole/controller/OrderController.java
+++ b/src/main/java/com/feelmycode/parabole/controller/OrderController.java
@@ -1,7 +1,9 @@
 package com.feelmycode.parabole.controller;
 
 import com.feelmycode.parabole.domain.Order;
+import com.feelmycode.parabole.dto.OrderDeliveryUpdateRequestDto;
 import com.feelmycode.parabole.dto.OrderUpdateRequestDto;
+import com.feelmycode.parabole.enumtype.OrderInfoState;
 import com.feelmycode.parabole.global.api.ParaboleResponse;
 import com.feelmycode.parabole.service.OrderInfoService;
 import com.feelmycode.parabole.service.OrderService;
@@ -11,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,20 +29,19 @@ public class OrderController {
     private static final Long DELIVERY_FEE = 0L;
 
     private final OrderService orderService;
-    private final UserService userService;
     private final OrderInfoService orderInfoService;
 
-    @GetMapping
-    public ResponseEntity<ParaboleResponse> createOrder(@RequestParam Long userId) {
-        log.info("Create Order. userId: {}", userId);
-        orderService.createOrder(new Order(userService.getUser(userId), DELIVERY_FEE));
-        return ParaboleResponse.CommonResponse(HttpStatus.CREATED, true, "주문 정보 생성 완료");
-    }
-
-    @PostMapping("/update")
+    @PostMapping
     public ResponseEntity<ParaboleResponse> updateOrder(@RequestBody OrderUpdateRequestDto orderUpdateRequestDto) {
         orderService.updateOrderState(orderUpdateRequestDto);
         return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "주문 수정 완료");
+    }
+
+    @PatchMapping
+    public ResponseEntity<ParaboleResponse> updateDelivery(@RequestBody OrderDeliveryUpdateRequestDto updateDto) {
+        orderService.updateDeliveryInfo(updateDto);
+        orderInfoService.updateOrderInfoState(updateDto.getUserId(), updateDto.getOrderInfoState());
+        return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "주문 정보 저장 완료");
     }
 
 }

--- a/src/main/java/com/feelmycode/parabole/controller/OrderInfoController.java
+++ b/src/main/java/com/feelmycode/parabole/controller/OrderInfoController.java
@@ -1,12 +1,15 @@
 package com.feelmycode.parabole.controller;
 
+import com.feelmycode.parabole.domain.Order;
 import com.feelmycode.parabole.dto.OrderInfoListDto;
+import com.feelmycode.parabole.dto.OrderInfoRequestDto;
 import com.feelmycode.parabole.dto.OrderInfoResponseDto;
 import com.feelmycode.parabole.dto.OrderInfoSimpleDto;
-import com.feelmycode.parabole.dto.OrderUpdateRequestDto;
 import com.feelmycode.parabole.global.api.ParaboleResponse;
 import com.feelmycode.parabole.global.error.exception.ParaboleException;
 import com.feelmycode.parabole.service.OrderInfoService;
+import com.feelmycode.parabole.service.OrderService;
+import com.feelmycode.parabole.service.UserService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,13 +29,21 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class OrderInfoController {
 
+    private static final Long DELIVERY_FEE = 0L;
+
+    private final OrderService orderService;
     private final OrderInfoService orderInfoService;
+    private final UserService userService;
 
     // TODO: order paging
     // TODO: userCoupon 정보 가져오기
     @PostMapping
     public ResponseEntity<ParaboleResponse> createOrderInfo(@RequestBody OrderInfoListDto orderInfoDto) {
         try {
+            if (orderService.isOrderEmpty(orderInfoDto.getUserId())) {
+                orderService.createOrder(orderInfoDto.getUserId(), new Order(userService.getUser(orderInfoDto.getUserId()), DELIVERY_FEE));
+            }
+
             for (OrderInfoSimpleDto orderInfo : orderInfoDto.getOrderInfoDto()) {
                 orderInfoService.saveOrderInfo(orderInfoDto.getUserId(), orderInfo);
             }
@@ -50,16 +61,17 @@ public class OrderInfoController {
         return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "주문 정보 목록 조회", orderInfoList);
     }
 
-    // sellerId를 인자로 받는다고 되어있지만 판매자가 로그인했을 때 userId를 가져옴.  seller 였을 때만 불러올 수 있도록
     @GetMapping("/seller")
-    public ResponseEntity<ParaboleResponse> getOrderInfoBySeller(@RequestParam Long sellerId) {
-        log.info("Seller Id: {} ", sellerId);
-        List<OrderInfoResponseDto> orderInfoList = orderInfoService.getOrderInfoListBySeller(sellerId);
-        for (OrderInfoResponseDto dto : orderInfoList) {
-            log.info(dto.toString());
-        }
-        return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "판매자의 상품 주문 정보 목록 조회",
-            orderInfoList);
+    public ResponseEntity<ParaboleResponse> getOrderInfoBySeller(@RequestParam Long userId) {
+        log.info("Seller Id: {} ", userId);
+        List<OrderInfoResponseDto> orderInfoList = orderInfoService.getOrderInfoListBySeller(userId);
+        return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "판매자의 상품 주문 정보 목록 조회",orderInfoList);
+    }
+
+    @PatchMapping
+    public ResponseEntity<ParaboleResponse> updateOrderInfo(@RequestBody OrderInfoRequestDto orderInfoRequestDto) {
+        orderInfoService.updateOrderInfoState(orderInfoRequestDto);
+        return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "사용자의 상세 주문 배송 정보 수정");
     }
 
 }

--- a/src/main/java/com/feelmycode/parabole/controller/OrderInfoController.java
+++ b/src/main/java/com/feelmycode/parabole/controller/OrderInfoController.java
@@ -40,14 +40,14 @@ public class OrderInfoController {
     // TODO: order paging
     // TODO: userCoupon 정보 가져오기
     @PostMapping
-    public ResponseEntity<ParaboleResponse> createOrderInfo(@RequestBody OrderInfoListDto orderInfoDto) {
+    public ResponseEntity<ParaboleResponse> createOrderInfo(@RequestBody OrderInfoListDto orderInfoListDto) {
         try {
-            if (orderService.isOrderEmpty(orderInfoDto.getUserId())) {
-                orderService.createOrder(new Order(userService.getUser(orderInfoDto.getUserId()), DELIVERY_FEE));
+            if (orderService.isOrderEmpty(orderInfoListDto.getUserId())) {
+                orderService.createOrder(new Order(userService.getUser(orderInfoListDto.getUserId()), DELIVERY_FEE));
             }
 
-            for (OrderInfoSimpleDto orderInfo : orderInfoDto.getOrderInfoDto()) {
-                orderInfoService.saveOrderInfo(orderInfoDto.getUserId(), orderInfo);
+            for (OrderInfoSimpleDto orderInfo : orderInfoListDto.getOrderInfoDto()) {
+                orderInfoService.saveOrderInfo(orderInfoListDto.getUserId(), orderInfo);
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/com/feelmycode/parabole/controller/OrderInfoController.java
+++ b/src/main/java/com/feelmycode/parabole/controller/OrderInfoController.java
@@ -34,8 +34,7 @@ public class OrderInfoController {
     public ResponseEntity<ParaboleResponse> createOrderInfo(@RequestBody OrderInfoListDto orderInfoDto) {
         try {
             for (OrderInfoSimpleDto orderInfo : orderInfoDto.getOrderInfoDto()) {
-                orderInfoService.saveOrderInfo(orderInfo);
-                log.info("ORDER INFO: {}", orderInfo.toString());
+                orderInfoService.saveOrderInfo(orderInfoDto.getUserId(), orderInfo);
             }
         } catch (Exception e) {
             e.printStackTrace();
@@ -61,14 +60,6 @@ public class OrderInfoController {
         }
         return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "판매자의 상품 주문 정보 목록 조회",
             orderInfoList);
-    }
-
-    @PatchMapping
-    public ResponseEntity<ParaboleResponse> updateOrderState(@RequestBody OrderUpdateRequestDto orderUpdate) {
-        log.info("Update Order. orderInfoId: {}", orderUpdate.getOrderId());
-        orderInfoService.updateOrderState(orderUpdate.getOrderInfoId(),
-            orderUpdate.getOrderState());
-        return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "주문 배송 상태 변경");
     }
 
 }

--- a/src/main/java/com/feelmycode/parabole/controller/OrderInfoController.java
+++ b/src/main/java/com/feelmycode/parabole/controller/OrderInfoController.java
@@ -9,6 +9,7 @@ import com.feelmycode.parabole.global.api.ParaboleResponse;
 import com.feelmycode.parabole.global.error.exception.ParaboleException;
 import com.feelmycode.parabole.service.OrderInfoService;
 import com.feelmycode.parabole.service.OrderService;
+import com.feelmycode.parabole.service.UpdateService;
 import com.feelmycode.parabole.service.UserService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +34,7 @@ public class OrderInfoController {
 
     private final OrderService orderService;
     private final OrderInfoService orderInfoService;
+    private final UpdateService updateService;
     private final UserService userService;
 
     // TODO: order paging
@@ -41,7 +43,7 @@ public class OrderInfoController {
     public ResponseEntity<ParaboleResponse> createOrderInfo(@RequestBody OrderInfoListDto orderInfoDto) {
         try {
             if (orderService.isOrderEmpty(orderInfoDto.getUserId())) {
-                orderService.createOrder(orderInfoDto.getUserId(), new Order(userService.getUser(orderInfoDto.getUserId()), DELIVERY_FEE));
+                orderService.createOrder(new Order(userService.getUser(orderInfoDto.getUserId()), DELIVERY_FEE));
             }
 
             for (OrderInfoSimpleDto orderInfo : orderInfoDto.getOrderInfoDto()) {
@@ -57,7 +59,7 @@ public class OrderInfoController {
     @GetMapping
     public ResponseEntity<ParaboleResponse> getOrderInfoList(@RequestParam Long userId) {
         log.info("Get Order List. userId: {}", userId);
-        List<OrderInfoResponseDto> orderInfoList = orderInfoService.getOrderInfoList(userId);
+        List<OrderInfoResponseDto> orderInfoList = orderInfoService.getOrderInfoListByUserId(userId);
         return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "주문 정보 목록 조회", orderInfoList);
     }
 
@@ -70,7 +72,7 @@ public class OrderInfoController {
 
     @PatchMapping
     public ResponseEntity<ParaboleResponse> updateOrderInfo(@RequestBody OrderInfoRequestDto orderInfoRequestDto) {
-        orderInfoService.updateOrderInfoState(orderInfoRequestDto);
+        updateService.updateOrderInfoState(orderInfoRequestDto);
         return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "사용자의 상세 주문 배송 정보 수정");
     }
 

--- a/src/main/java/com/feelmycode/parabole/domain/Order.java
+++ b/src/main/java/com/feelmycode/parabole/domain/Order.java
@@ -1,5 +1,8 @@
 package com.feelmycode.parabole.domain;
 
+import com.feelmycode.parabole.dto.OrderDeliveryUpdateRequestDto;
+import com.feelmycode.parabole.enumtype.OrderPayState;
+import com.feelmycode.parabole.enumtype.OrderState;
 import com.sun.istack.NotNull;
 import java.util.ArrayList;
 import java.util.List;
@@ -16,11 +19,13 @@ import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Entity
 @Table(name = "orders")
 @Getter
 @NoArgsConstructor
+@Slf4j
 public class Order extends BaseEntity {
 
     @Id
@@ -81,14 +86,22 @@ public class Order extends BaseEntity {
     private Integer state;
 
     @NotNull
-    @Column(name="order_pay_state")
-    private Integer pay_state;
+    @Column(name = "order_pay_state")
+    private Integer payState;
 
     private void setTotal(List<OrderInfo> orderInfoList) {
         this.total = orderInfoList
             .stream()
             .mapToLong(OrderInfo::getProductPrice)
             .sum();
+    }
+
+    public void setState(String state) {
+        this.state = OrderState.returnValueByName(state).getValue();
+    }
+
+    public void setState(Integer value) {
+        this.state = value;
     }
 
     private void setDeliveryFee(Long orderDeliveryFee) {
@@ -99,23 +112,21 @@ public class Order extends BaseEntity {
         this.user = user;
         this.setTotal(getOrderInfoList());
         this.deliveryFee = deliveryFee;
+        this.setState(-1);
     }
 
-    @Override
-    public String toString() {
-        return "Order{" +
-            "id=" + id +
-            ", user=" + user +
-            ", total=" + total +
-            ", userName='" + userName + '\'' +
-            ", userEmail='" + userEmail + '\'' +
-            ", userPhone='" + userPhone + '\'' +
-            ", receiverName='" + receiverName + '\'' +
-            ", receiverPhone='" + receiverPhone + '\'' +
-            ", addressSimple='" + addressSimple + '\'' +
-            ", addressDetail='" + addressDetail + '\'' +
-            ", deliveryComment='" + deliveryComment + '\'' +
-            ", deliveryFee=" + deliveryFee +
-            '}';
+    public Order saveDeliveryInfo(OrderDeliveryUpdateRequestDto deliveryDto) {
+        this.userName = deliveryDto.getUserName();
+        this.userEmail = deliveryDto.getUserEmail();
+        this.userPhone = deliveryDto.getUserPhone();
+        this.receiverName = deliveryDto.getReceiverName();
+        this.receiverPhone = deliveryDto.getReceiverPhone();
+        this.addressSimple = deliveryDto.getAddressSimple();
+        this.addressDetail = deliveryDto.getAddressDetail();
+        this.deliveryComment = deliveryDto.getDeliveryComment();
+        this.state = 0;
+        this.payState = OrderPayState.returnValueByName(deliveryDto.getPayState());
+        return this;
     }
+
 }

--- a/src/main/java/com/feelmycode/parabole/domain/Order.java
+++ b/src/main/java/com/feelmycode/parabole/domain/Order.java
@@ -75,13 +75,14 @@ public class Order extends BaseEntity {
     @Column(name = "order_delivery_fee")
     private Long deliveryFee;
 
-    public void setDeleted() {
-        this.isDeleted = false;
-    }
+    // TODO: enum으로 처리하기
+    @NotNull
+    @Column(name = "order_state")
+    private Integer state;
 
-    private void setOrderInfoList(List<OrderInfo> orderInfoList) {
-        this.orderInfoList = orderInfoList;
-    }
+    @NotNull
+    @Column(name="order_pay_state")
+    private Integer pay_state;
 
     private void setTotal(List<OrderInfo> orderInfoList) {
         this.total = orderInfoList
@@ -94,18 +95,27 @@ public class Order extends BaseEntity {
         this.deliveryFee = orderDeliveryFee;
     }
 
-    // TODO: 주문상세 정보 list로 추가하기
-
     public Order(User user, Long deliveryFee) {
         this.user = user;
         this.setTotal(getOrderInfoList());
         this.deliveryFee = deliveryFee;
     }
 
-    public Order setOrder(List<OrderInfo> orderInfoList) {
-        this.setOrderInfoList(orderInfoList);
-        this.setTotal(orderInfoList);
-        return this;
+    @Override
+    public String toString() {
+        return "Order{" +
+            "id=" + id +
+            ", user=" + user +
+            ", total=" + total +
+            ", userName='" + userName + '\'' +
+            ", userEmail='" + userEmail + '\'' +
+            ", userPhone='" + userPhone + '\'' +
+            ", receiverName='" + receiverName + '\'' +
+            ", receiverPhone='" + receiverPhone + '\'' +
+            ", addressSimple='" + addressSimple + '\'' +
+            ", addressDetail='" + addressDetail + '\'' +
+            ", deliveryComment='" + deliveryComment + '\'' +
+            ", deliveryFee=" + deliveryFee +
+            '}';
     }
-
 }

--- a/src/main/java/com/feelmycode/parabole/domain/OrderInfo.java
+++ b/src/main/java/com/feelmycode/parabole/domain/OrderInfo.java
@@ -2,7 +2,7 @@ package com.feelmycode.parabole.domain;
 
 import com.feelmycode.parabole.dto.OrderInfoResponseDto;
 import com.feelmycode.parabole.enumtype.OrderPayState;
-import com.feelmycode.parabole.enumtype.OrderState;
+import com.feelmycode.parabole.enumtype.OrderInfoState;
 import com.sun.istack.NotNull;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -28,7 +28,6 @@ public class OrderInfo extends BaseEntity {
             "id=" + id +
             ", order=" + order +
             ", state=" + state +
-            ", payState=" + payState +
             ", productId=" + productId +
             ", productName='" + productName + '\'' +
             ", productCnt=" + productCnt +
@@ -54,10 +53,6 @@ public class OrderInfo extends BaseEntity {
     // 배송의 상태
     @Column(name = "order_info_state")
     private Integer state;
-
-    // 주문방식
-    @Column(name = "order_info_pay_state")
-    private Integer payState;
 
     @NotNull
     @Column(name = "product_id")
@@ -91,13 +86,12 @@ public class OrderInfo extends BaseEntity {
         this.state = state;
     }
 
-    public OrderInfo(Order order, UserCoupon userCoupon, Integer state, String payState,
+    public OrderInfo(Order order, UserCoupon userCoupon, Integer state,
         Long productId, String productName, Integer productCnt,
         Long productPrice, Long productDiscountPrice, Long sellerId, String sellerStoreName) {
         this.order = order;
 //        this.userCoupon = userCoupon;
         this.state = state;
-        this.payState = OrderPayState.returnValueByName(payState);
         this.productId = productId;
         this.productName = productName;
         this.productCnt = productCnt;
@@ -107,21 +101,18 @@ public class OrderInfo extends BaseEntity {
         this.sellerStoreName = sellerStoreName;
     }
 
-    public OrderInfo(Order order, String state, String payState, Long productId,
+    public OrderInfo(Order order, String state, Long productId,
         String productName, Long productPrice) {
         this.order = order;
         this.state = OrderPayState.returnValueByName(state);
-        this.payState = OrderPayState.returnValueByName(payState);
         this.productId = productId;
         this.productName = productName;
         this.productPrice = productPrice;
     }
 
-    public OrderInfo(Order order, String payState, Long productId,
+    public OrderInfo(Order order, Long productId,
         String productName, Integer productCnt, Long productPrice) {
         this.order = order;
-        payState = payState.trim();
-        this.payState = OrderPayState.returnValueByName(payState);
         this.productId = productId;
         this.productName = productName;
         this.productCnt = productCnt;
@@ -129,8 +120,7 @@ public class OrderInfo extends BaseEntity {
     }
 
     public OrderInfoResponseDto toDto() {
-        return new OrderInfoResponseDto(id, OrderState.returnNameByValue(state),
-            OrderState.returnNameByValue(payState), order.getUser().getId(),
+        return new OrderInfoResponseDto(id, OrderInfoState.returnNameByValue(state), order.getUser().getId(),
             order.getUser().getEmail(), productId, productName, productCnt, productPrice,
             productDiscountPrice);
     }

--- a/src/main/java/com/feelmycode/parabole/domain/OrderInfo.java
+++ b/src/main/java/com/feelmycode/parabole/domain/OrderInfo.java
@@ -1,7 +1,6 @@
 package com.feelmycode.parabole.domain;
 
 import com.feelmycode.parabole.dto.OrderInfoResponseDto;
-import com.feelmycode.parabole.enumtype.OrderPayState;
 import com.feelmycode.parabole.enumtype.OrderInfoState;
 import com.sun.istack.NotNull;
 import javax.persistence.Column;
@@ -21,22 +20,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Table(name = "order_infos")
 public class OrderInfo extends BaseEntity {
-
-    @Override
-    public String toString() {
-        return "OrderInfo{" +
-            "id=" + id +
-            ", order=" + order +
-            ", state=" + state +
-            ", productId=" + productId +
-            ", productName='" + productName + '\'' +
-            ", productCnt=" + productCnt +
-            ", productPrice=" + productPrice +
-            ", productDiscountPrice=" + productDiscountPrice +
-            ", sellerId=" + sellerId +
-            ", sellerStoreName='" + sellerStoreName + '\'' +
-            '}';
-    }
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -101,22 +84,15 @@ public class OrderInfo extends BaseEntity {
         this.sellerStoreName = sellerStoreName;
     }
 
-    public OrderInfo(Order order, String state, Long productId,
-        String productName, Long productPrice) {
-        this.order = order;
-        this.state = OrderPayState.returnValueByName(state);
-        this.productId = productId;
-        this.productName = productName;
-        this.productPrice = productPrice;
-    }
-
     public OrderInfo(Order order, Long productId,
-        String productName, Integer productCnt, Long productPrice) {
+        String productName, Integer productCnt, Long productPrice, Long sellerId, String sellerStoreName) {
         this.order = order;
         this.productId = productId;
         this.productName = productName;
         this.productCnt = productCnt;
         this.productPrice = productPrice;
+        this.sellerId = sellerId;
+        this.sellerStoreName = sellerStoreName;
     }
 
     public OrderInfoResponseDto toDto() {

--- a/src/main/java/com/feelmycode/parabole/domain/Product.java
+++ b/src/main/java/com/feelmycode/parabole/domain/Product.java
@@ -138,19 +138,4 @@ public class Product extends BaseEntity {
         this.productDetailList = productDetailList;
     }
 
-    @Override
-    public String toString() {
-        return "Product{" +
-            "id=" + id +
-            ", seller=" + seller +
-            ", name='" + name + '\'' +
-            ", salesStatus=" + salesStatus +
-            ", remains=" + remains +
-            ", price=" + price +
-            ", category='" + category + '\'' +
-            ", thumbnailImg='" + thumbnailImg + '\'' +
-            ", productDetailList=" + productDetailList +
-            ", isDeleted=" + isDeleted +
-            '}';
-    }
 }

--- a/src/main/java/com/feelmycode/parabole/dto/OrderDeliveryUpdateRequestDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/OrderDeliveryUpdateRequestDto.java
@@ -1,0 +1,23 @@
+package com.feelmycode.parabole.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OrderDeliveryUpdateRequestDto {
+
+    private Long userId;
+    private String userName;
+    private String userEmail;
+    private String userPhone;
+    private String receiverName;
+    private String receiverPhone;
+    private String addressSimple;
+    private String addressDetail;
+    private String deliveryComment;
+    private String orderState;
+    private String orderInfoState;
+    private String payState;
+
+}

--- a/src/main/java/com/feelmycode/parabole/dto/OrderInfoListDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/OrderInfoListDto.java
@@ -6,15 +6,7 @@ import lombok.Getter;
 @Getter
 public class OrderInfoListDto {
 
+    private Long userId;
     private List<OrderInfoSimpleDto> orderInfoDto;
-
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        for(OrderInfoSimpleDto dto : orderInfoDto) {
-            sb.append(dto.toString()).append("\n");
-        }
-        return sb.toString();
-    }
 
 }

--- a/src/main/java/com/feelmycode/parabole/dto/OrderInfoListDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/OrderInfoListDto.java
@@ -1,9 +1,12 @@
 package com.feelmycode.parabole.dto;
 
 import java.util.List;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class OrderInfoListDto {
 
     private Long userId;

--- a/src/main/java/com/feelmycode/parabole/dto/OrderInfoRequestDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/OrderInfoRequestDto.java
@@ -11,9 +11,8 @@ public class OrderInfoRequestDto {
     private Long orderInfoId;
     private String orderState;
 
-    public OrderInfoRequestDto(Long userId, Long orderInfoId, String orderState) {
+    public OrderInfoRequestDto(Long userId, String orderState) {
         this.userId = userId;
-        this.orderInfoId = orderInfoId;
         this.orderState = orderState;
     }
 

--- a/src/main/java/com/feelmycode/parabole/dto/OrderInfoRequestDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/OrderInfoRequestDto.java
@@ -1,0 +1,20 @@
+package com.feelmycode.parabole.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class OrderInfoRequestDto {
+
+    private Long userId;
+    private Long orderInfoId;
+    private String orderState;
+
+    public OrderInfoRequestDto(Long userId, Long orderInfoId, String orderState) {
+        this.userId = userId;
+        this.orderInfoId = orderInfoId;
+        this.orderState = orderState;
+    }
+
+}

--- a/src/main/java/com/feelmycode/parabole/dto/OrderInfoResponseDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/OrderInfoResponseDto.java
@@ -10,7 +10,6 @@ public class OrderInfoResponseDto {
 
     private Long id;
     private String state;
-    private String payState;
     private Long userId;
     private String userEmail;
     private Long productId;
@@ -21,11 +20,10 @@ public class OrderInfoResponseDto {
     private Long productDiscountPrice;
     private String productThumbnailImg;
 
-    public OrderInfoResponseDto(Long id, String state, String payState, Long userId, String userEmail, Long productId, String productName,
+    public OrderInfoResponseDto(Long id, String state, Long userId, String userEmail, Long productId, String productName,
         Integer productCnt, Long productPrice, Long productDiscountPrice) {
         this.id = id;
         this.state = state;
-        this.payState = payState;
         this.userId = userId;
         this.userEmail = userEmail;
         this.productId = productId;

--- a/src/main/java/com/feelmycode/parabole/dto/OrderInfoSimpleDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/OrderInfoSimpleDto.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class OrderInfoSimpleDto {
 

--- a/src/main/java/com/feelmycode/parabole/dto/OrderInfoSimpleDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/OrderInfoSimpleDto.java
@@ -10,10 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class OrderInfoSimpleDto {
 
-    private Long userId;
     private Long productId;
-    private String productName;
     private Integer productCnt;
-    private Long productPrice;
 
 }

--- a/src/main/java/com/feelmycode/parabole/dto/OrderInfoSimpleDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/OrderInfoSimpleDto.java
@@ -1,6 +1,5 @@
 package com.feelmycode.parabole.dto;
 
-import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,5 +11,6 @@ public class OrderInfoSimpleDto {
 
     private Long productId;
     private Integer productCnt;
+    private Long sellerId;
 
 }

--- a/src/main/java/com/feelmycode/parabole/dto/OrderUpdateRequestDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/OrderUpdateRequestDto.java
@@ -7,13 +7,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class OrderUpdateRequestDto {
 
-    private Long orderId;
-    private Long orderInfoId;
+    private Long userId;
     private String orderState;
 
-    public OrderUpdateRequestDto(Long orderId, Long orderInfoId, String orderState) {
-        this.orderId = orderId;
-        this.orderInfoId = orderInfoId;
+    public OrderUpdateRequestDto(Long userId, String orderState) {
+        this.userId = userId;
         this.orderState = orderState;
     }
 

--- a/src/main/java/com/feelmycode/parabole/enumtype/OrderInfoState.java
+++ b/src/main/java/com/feelmycode/parabole/enumtype/OrderInfoState.java
@@ -1,0 +1,44 @@
+package com.feelmycode.parabole.enumtype;
+
+import java.util.Arrays;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderInfoState {
+
+    // 입금전, 주문완료(결제), 배송준비, 배송중, 배송완료,
+    // (리뷰 작성 전, 리뷰 작성 완료), 취소, 반품
+    BEFORE_PAY("BEFORE_PAY", 1),
+    PAY_COMPLETE("PAY_COMPLETE", 2),
+    BEFORE_DELIVERY("BEFORE_DELIVERY", 3),
+    DELIVERY("DELIVERY", 4),
+    DELIVERY_COMPLETE("DELIVERY_COMPLETE", 5),
+//    BEFORE_REVIEW("BEFORE_REVIEW", 6),
+//    REVIEW_COMPLETE("REVIEW_COMPLETE", 7),
+    BEFORE_ORDER("BEFORE_ORDER", -1),
+    ORDER_CANCEL("ORDER_CANCEL", -2),
+    REFUND("REFUND", -3),
+    ERROR("ERROR", -99);
+
+    private final String state;
+    private final Integer value;
+
+    public static Integer returnValueByName(String state) {
+        return Arrays.stream(values())
+            .filter(orderInfoState -> orderInfoState.state.equals(state))
+            .map(orderInfoState -> orderInfoState.value)
+            .findFirst()
+            .orElse(-99);
+    }
+
+    public static String returnNameByValue(Integer value) {
+        return Arrays.stream(values())
+            .filter(orderInfoState -> orderInfoState.value.toString().equals(value))
+            .map(orderInfoState -> orderInfoState.state)
+            .findFirst()
+            .orElse("ERROR");
+    }
+
+}

--- a/src/main/java/com/feelmycode/parabole/enumtype/OrderInfoState.java
+++ b/src/main/java/com/feelmycode/parabole/enumtype/OrderInfoState.java
@@ -35,7 +35,7 @@ public enum OrderInfoState {
 
     public static String returnNameByValue(Integer value) {
         return Arrays.stream(values())
-            .filter(orderInfoState -> orderInfoState.value.toString().equals(value))
+            .filter(orderInfoState -> orderInfoState.value.toString().equals(value.toString()))
             .map(orderInfoState -> orderInfoState.state)
             .findFirst()
             .orElse("ERROR");

--- a/src/main/java/com/feelmycode/parabole/enumtype/OrderPayState.java
+++ b/src/main/java/com/feelmycode/parabole/enumtype/OrderPayState.java
@@ -39,28 +39,12 @@ public enum OrderPayState {
     }
 
     // TODO: Stream으로 구현하기
-    public static OrderPayState returnNameByValue(Integer value) {
-        switch (value) {
-            case 1:
-                return OrderPayState.CARD;
-            case 2:
-                return OrderPayState.BANK_TRANSFER;
-            case 3:
-                return OrderPayState.PHONE;
-            case 4:
-                return OrderPayState.VIRTUAL_ACCOUNT;
-            case 5:
-                return OrderPayState.KAKAO_PAY;
-            case 6:
-                return OrderPayState.TOSS;
-            case 7:
-                return OrderPayState.WITHOUT_BANK;
-            case 8:
-                return OrderPayState.WITHOUT_BANK_PAY;
-            case 9:
-                return OrderPayState.NAVER_PAY;
-        }
-        return OrderPayState.ERROR;
+    public static String returnNameByValue(Integer value) {
+        return Arrays.stream(values())
+            .filter(orderPayState -> orderPayState.value.toString().equals(value))
+            .map(orderPayState -> orderPayState.state)
+            .findFirst()
+            .orElse("ERROR");
     }
 
 }

--- a/src/main/java/com/feelmycode/parabole/enumtype/OrderPayState.java
+++ b/src/main/java/com/feelmycode/parabole/enumtype/OrderPayState.java
@@ -41,7 +41,7 @@ public enum OrderPayState {
     // TODO: Stream으로 구현하기
     public static String returnNameByValue(Integer value) {
         return Arrays.stream(values())
-            .filter(orderPayState -> orderPayState.value.toString().equals(value))
+            .filter(orderPayState -> orderPayState.value.toString().equals(value.toString()))
             .map(orderPayState -> orderPayState.state)
             .findFirst()
             .orElse("ERROR");

--- a/src/main/java/com/feelmycode/parabole/enumtype/OrderState.java
+++ b/src/main/java/com/feelmycode/parabole/enumtype/OrderState.java
@@ -1,5 +1,6 @@
 package com.feelmycode.parabole.enumtype;
 
+import java.util.Arrays;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -7,67 +8,27 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum OrderState {
 
-    // 입금전, 주문완료(결제), 배송준비, 배송중, 배송완료,
-    // (리뷰 작성 전, 리뷰 작성 완료), 취소, 반품
-    BEFORE_PAY("BEFORE_PAY", 1),
-    PAY_COMPLETE("PAY_COMPLETE", 2),
-    BEFORE_DELIVERY("BEFORE_DELIVERY", 3),
-    DELIVERY("DELIVERY", 4),
-    DELIVERY_COMPLETE("DELIVERY_COMPLETE", 5),
-//    BEFORE_REVIEW("BEFORE_REVIEW", 6),
-//    REVIEW_COMPLETE("REVIEW_COMPLETE", 7),
-    ORDER_CANCEL("ORDER_CANCEL", -1),
-    REFUND("REFUND", -2),
-    ERROR("ERROR", -99);
+    BEFORE_PAY("주문 확정 전", -1),
+    PAY_COMPLETE("주문 확정", 0),
+    DELIVERY_COMPLETE("모든 배송 완료", 1);
 
     private final String state;
     private final Integer value;
 
     public static Integer returnValueByName(String state) {
-        if (state.equals(REFUND.state)) {
-            return -2;
-        } else if (state.equals(ORDER_CANCEL.state)) {
-            return -1;
-        } else if (state.equals(BEFORE_PAY.state)) {
-            return 1;
-        } else if (state.equals(PAY_COMPLETE.state)) {
-            return 2;
-        } else if (state.equals(BEFORE_DELIVERY.state)) {
-            return 3;
-        } else if (state.equals(DELIVERY.state)) {
-            return 4;
-        } else if (state.equals(DELIVERY_COMPLETE.state)) {
-            return 5;
-//        } else if (state.equals(BEFORE_REVIEW.state)) {
-//            return 6;
-//        } else if (state.equals(REVIEW_COMPLETE.state)) {
-//            return 7;
-        }
-        return -99;
+        return Arrays.stream(values())
+            .filter(orderState -> orderState.state.equals(state))
+            .map(orderState -> orderState.value)
+            .findFirst()
+            .orElse(-99);
     }
 
     public static String returnNameByValue(Integer value) {
-        switch (value) {
-            case -2:
-                return REFUND.state;
-            case -1:
-                return ORDER_CANCEL.state;
-            case 1:
-                return BEFORE_PAY.state;
-            case 2:
-                return PAY_COMPLETE.state;
-            case 3:
-                return BEFORE_DELIVERY.state;
-            case 4:
-                return DELIVERY.state;
-            case 5:
-                return DELIVERY_COMPLETE.state;
-//            case 6:
-//                return BEFORE_REVIEW.state;
-//            case 7:
-//                return REVIEW_COMPLETE.state;
-        }
-        return ERROR.state;
+        return Arrays.stream(values())
+            .filter(orderState -> orderState.value.toString().equals(value))
+            .map(orderState -> orderState.state)
+            .findFirst()
+            .orElse("ERROR");
     }
 
 }

--- a/src/main/java/com/feelmycode/parabole/enumtype/OrderState.java
+++ b/src/main/java/com/feelmycode/parabole/enumtype/OrderState.java
@@ -8,24 +8,25 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum OrderState {
 
+    // OrderInfoState와는 달리 전체적인 주문의 배송완료여부를 판단한다.
     BEFORE_PAY("주문 확정 전", -1),
     PAY_COMPLETE("주문 확정", 0),
-    DELIVERY_COMPLETE("모든 배송 완료", 1);
+    DELIVERY_COMPLETE("모든 배송 완료", 1),
+    ERROR("에러", -99);
 
     private final String state;
     private final Integer value;
 
-    public static Integer returnValueByName(String state) {
+    public static OrderState returnValueByName(String state) {
         return Arrays.stream(values())
             .filter(orderState -> orderState.state.equals(state))
-            .map(orderState -> orderState.value)
-            .findFirst()
-            .orElse(-99);
+            .findAny()
+            .orElse(ERROR);
     }
 
     public static String returnNameByValue(Integer value) {
         return Arrays.stream(values())
-            .filter(orderState -> orderState.value.toString().equals(value))
+            .filter(orderState -> orderState.value.toString().equals(value.toString()))
             .map(orderState -> orderState.state)
             .findFirst()
             .orElse("ERROR");

--- a/src/main/java/com/feelmycode/parabole/service/OrderInfoService.java
+++ b/src/main/java/com/feelmycode/parabole/service/OrderInfoService.java
@@ -3,22 +3,15 @@ package com.feelmycode.parabole.service;
 import com.feelmycode.parabole.domain.Order;
 import com.feelmycode.parabole.domain.OrderInfo;
 import com.feelmycode.parabole.domain.Product;
-import com.feelmycode.parabole.domain.Seller;
-import com.feelmycode.parabole.dto.OrderInfoRequestDto;
 import com.feelmycode.parabole.dto.OrderInfoResponseDto;
 import com.feelmycode.parabole.dto.OrderInfoSimpleDto;
-import com.feelmycode.parabole.dto.OrderUpdateRequestDto;
 import com.feelmycode.parabole.dto.SellerDto;
 import com.feelmycode.parabole.enumtype.OrderInfoState;
-import com.feelmycode.parabole.enumtype.OrderState;
-import com.feelmycode.parabole.global.error.exception.ParaboleException;
-import com.feelmycode.parabole.repository.CartItemRepository;
 import com.feelmycode.parabole.repository.OrderInfoRepository;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,26 +21,14 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class OrderInfoService {
 
-    private static final Long DELIVERY_FEE = 0L;
-
     private final OrderInfoRepository orderInfoRepository;
     private final OrderService orderService;
-    private final UserService userService;
     private final ProductService productService;
     private final SellerService sellerService;
 
     @Transactional
     public void saveOrderInfo(Long userId, OrderInfoSimpleDto orderInfoDto) {
         Order order = orderService.getOrder(userId);
-
-//        if (order == null) {
-//            order = orderService.createOrder(new Order(userService.getUser(userId), DELIVERY_FEE));
-//        }
-//        // 이미 저장된 주문(취소했던 주문)이 있을 경우
-//        else if (order.getState() < 0) {
-//            orderService.deleteOrder(order.getId());
-//            order = orderService.createOrder(new Order(userService.getUser(userId), DELIVERY_FEE));
-//        }
 
         Product product = productService.getProduct(orderInfoDto.getProductId());
         SellerDto seller = sellerService.getSellerBySellerId(orderInfoDto.getSellerId());
@@ -60,40 +41,22 @@ public class OrderInfoService {
             seller.getSellerId(),
             seller.getStoreName());
 
-        // 각각의 주문상품에 대한 배달 여부
+        // 각각의 주문상품에 대한 배달 여부 저장(default -1)
         orderInfo.setState(-1);
 
         orderInfoRepository.save(orderInfo);
     }
 
-    @Transactional
-    public void updateOrderInfoState(OrderInfoRequestDto orderInfoRequestDto) {
-        try {
-            OrderInfo getOrderInfo = orderInfoRepository.findById(orderInfoRequestDto.getOrderInfoId())
-                .orElseThrow(() -> new ParaboleException(HttpStatus.NOT_FOUND, "주문정보를 찾을 수 없습니다."));
-
-            getOrderInfo.setState(OrderInfoState.returnValueByName(orderInfoRequestDto.getOrderState()));
-
-            // 모든 상품이 배송완료일 때 주문이 완료되었다고 처리
-            if(isDeliveryComplete(orderInfoRequestDto.getUserId())) {
-                orderService.updateOrderState(new OrderUpdateRequestDto(
-                    orderInfoRequestDto.getUserId(), OrderState.returnNameByValue(1)));
-            }
-        } catch (Exception e) {
-            throw new ParaboleException(HttpStatus.UNAUTHORIZED, "주문정보를 수정하는 중 문제가 발생했습니다.");
-        }
-    }
-
     public boolean isDeliveryComplete(Long userId) {
-        List<OrderInfoResponseDto> orderInfoResponseDtoList = getOrderInfoList(userId);
+        List<OrderInfoResponseDto> orderInfoResponseDtoList = getOrderInfoListByUserId(userId);
         return orderInfoResponseDtoList.stream()
             .allMatch(dto -> OrderInfoState.returnValueByName(dto.getState()) > 5);
     }
 
     // TODO: 자동으로 상품에 적용할 수 있는 최대 쿠폰을 적용할 수 있게 하기
-    public List<OrderInfoResponseDto> getOrderInfoList(Long userId) {
+    public List<OrderInfoResponseDto> getOrderInfoListByUserId(Long userId) {
         Order order = orderService.getOrder(userId);
-        List<OrderInfo> getOrderInfoList = getOrderInfo(order.getId());
+        List<OrderInfo> getOrderInfoList = getOrderInfoListByOrderId(order.getId());
         return changeEntityToDto(getOrderInfoList);
     }
 
@@ -103,17 +66,8 @@ public class OrderInfoService {
         return changeEntityToDto(getOrderInfoList);
     }
 
-    public List<OrderInfo> getOrderInfo(Long orderId) {
+    public List<OrderInfo> getOrderInfoListByOrderId(Long orderId) {
         return orderInfoRepository.findAllByOrderId(orderId);
-    }
-
-    @Transactional
-    public void updateOrderInfoState(Long userId, String state) {
-        Order order = orderService.getOrder(userId);
-        List<OrderInfo> getOrderInfoList = getOrderInfo(order.getId());
-        for(OrderInfo info : getOrderInfoList) {
-            info.setState(OrderInfoState.returnValueByName(state));
-        }
     }
 
     public List<OrderInfoResponseDto> changeEntityToDto(List<OrderInfo> orderInfoList) {

--- a/src/main/java/com/feelmycode/parabole/service/OrderInfoService.java
+++ b/src/main/java/com/feelmycode/parabole/service/OrderInfoService.java
@@ -3,9 +3,14 @@ package com.feelmycode.parabole.service;
 import com.feelmycode.parabole.domain.Order;
 import com.feelmycode.parabole.domain.OrderInfo;
 import com.feelmycode.parabole.domain.Product;
+import com.feelmycode.parabole.domain.Seller;
+import com.feelmycode.parabole.dto.OrderInfoRequestDto;
 import com.feelmycode.parabole.dto.OrderInfoResponseDto;
 import com.feelmycode.parabole.dto.OrderInfoSimpleDto;
+import com.feelmycode.parabole.dto.OrderUpdateRequestDto;
+import com.feelmycode.parabole.dto.SellerDto;
 import com.feelmycode.parabole.enumtype.OrderInfoState;
+import com.feelmycode.parabole.enumtype.OrderState;
 import com.feelmycode.parabole.global.error.exception.ParaboleException;
 import com.feelmycode.parabole.repository.CartItemRepository;
 import com.feelmycode.parabole.repository.OrderInfoRepository;
@@ -29,46 +34,66 @@ public class OrderInfoService {
     private final OrderService orderService;
     private final UserService userService;
     private final ProductService productService;
-    private final CartItemRepository cartItemRepository;
-    private final CartService cartService;
-
+    private final SellerService sellerService;
 
     @Transactional
     public void saveOrderInfo(Long userId, OrderInfoSimpleDto orderInfoDto) {
         Order order = orderService.getOrder(userId);
-        if (order == null) {
-            order = orderService.createOrder(new Order(userService.getUser(userId), DELIVERY_FEE));
-        }
-        else if (order.getState() == -1) {
-            orderService.deleteOrder(order.getId());
-            order = orderService.createOrder(new Order(userService.getUser(userId), DELIVERY_FEE));
-        }
+
+//        if (order == null) {
+//            order = orderService.createOrder(new Order(userService.getUser(userId), DELIVERY_FEE));
+//        }
+//        // 이미 저장된 주문(취소했던 주문)이 있을 경우
+//        else if (order.getState() < 0) {
+//            orderService.deleteOrder(order.getId());
+//            order = orderService.createOrder(new Order(userService.getUser(userId), DELIVERY_FEE));
+//        }
+
         Product product = productService.getProduct(orderInfoDto.getProductId());
+        SellerDto seller = sellerService.getSellerBySellerId(orderInfoDto.getSellerId());
+
         OrderInfo orderInfo = new OrderInfo(order,
             orderInfoDto.getProductId(),
             product.getName(),
             orderInfoDto.getProductCnt(),
-            product.getPrice());
+            product.getPrice(),
+            seller.getSellerId(),
+            seller.getStoreName());
+
+        // 각각의 주문상품에 대한 배달 여부
         orderInfo.setState(-1);
+
         orderInfoRepository.save(orderInfo);
     }
 
     @Transactional
-    public void updateOrderInfoState(Long orderInfoId, String orderState) {
+    public void updateOrderInfoState(OrderInfoRequestDto orderInfoRequestDto) {
         try {
-            OrderInfo getOrderInfo = orderInfoRepository.findById(orderInfoId)
+            OrderInfo getOrderInfo = orderInfoRepository.findById(orderInfoRequestDto.getOrderInfoId())
                 .orElseThrow(() -> new ParaboleException(HttpStatus.NOT_FOUND, "주문정보를 찾을 수 없습니다."));
 
-            getOrderInfo.setState(OrderInfoState.returnValueByName(orderState));
+            getOrderInfo.setState(OrderInfoState.returnValueByName(orderInfoRequestDto.getOrderState()));
+
+            // 모든 상품이 배송완료일 때 주문이 완료되었다고 처리
+            if(isDeliveryComplete(orderInfoRequestDto.getUserId())) {
+                orderService.updateOrderState(new OrderUpdateRequestDto(
+                    orderInfoRequestDto.getUserId(), OrderState.returnNameByValue(1)));
+            }
         } catch (Exception e) {
             throw new ParaboleException(HttpStatus.UNAUTHORIZED, "주문정보를 수정하는 중 문제가 발생했습니다.");
         }
     }
 
+    public boolean isDeliveryComplete(Long userId) {
+        List<OrderInfoResponseDto> orderInfoResponseDtoList = getOrderInfoList(userId);
+        return orderInfoResponseDtoList.stream()
+            .allMatch(dto -> OrderInfoState.returnValueByName(dto.getState()) > 5);
+    }
+
     // TODO: 자동으로 상품에 적용할 수 있는 최대 쿠폰을 적용할 수 있게 하기
     public List<OrderInfoResponseDto> getOrderInfoList(Long userId) {
         Order order = orderService.getOrder(userId);
-        List<OrderInfo> getOrderInfoList = orderInfoRepository.findAllByOrderId(order.getId());
+        List<OrderInfo> getOrderInfoList = getOrderInfo(order.getId());
         return changeEntityToDto(getOrderInfoList);
     }
 
@@ -76,6 +101,19 @@ public class OrderInfoService {
         log.info("Service sellerId: {}", sellerId);
         List<OrderInfo> getOrderInfoList = orderInfoRepository.findAllBySellerId(sellerId);
         return changeEntityToDto(getOrderInfoList);
+    }
+
+    public List<OrderInfo> getOrderInfo(Long orderId) {
+        return orderInfoRepository.findAllByOrderId(orderId);
+    }
+
+    @Transactional
+    public void updateOrderInfoState(Long userId, String state) {
+        Order order = orderService.getOrder(userId);
+        List<OrderInfo> getOrderInfoList = getOrderInfo(order.getId());
+        for(OrderInfo info : getOrderInfoList) {
+            info.setState(OrderInfoState.returnValueByName(state));
+        }
     }
 
     public List<OrderInfoResponseDto> changeEntityToDto(List<OrderInfo> orderInfoList) {

--- a/src/main/java/com/feelmycode/parabole/service/OrderService.java
+++ b/src/main/java/com/feelmycode/parabole/service/OrderService.java
@@ -1,7 +1,14 @@
 package com.feelmycode.parabole.service;
 
+import com.feelmycode.parabole.domain.Cart;
+import com.feelmycode.parabole.domain.CartItem;
 import com.feelmycode.parabole.domain.Order;
+import com.feelmycode.parabole.dto.OrderUpdateRequestDto;
+import com.feelmycode.parabole.enumtype.OrderState;
+import com.feelmycode.parabole.repository.CartItemRepository;
 import com.feelmycode.parabole.repository.OrderRepository;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -17,6 +24,8 @@ public class OrderService {
 
     private final OrderRepository orderRepository;
     private final UserService userService;
+    private final CartItemRepository cartItemRepository;
+    private final CartService cartService;
 
     @Transactional
     public Order createOrder(Order order) {
@@ -36,16 +45,30 @@ public class OrderService {
     @Transactional
     public void deleteOrder(Long orderId) {
         Order getOrder = getOrder(orderId);
-        getOrder.setDeleted();
+        orderRepository.deleteById(orderId);
     }
 
     public Order getOrderByUserId(Long userId) {
         return orderRepository.findTop1ByUserIdOrderByIdDesc(userId);
     }
 
+    public void updateOrderState(OrderUpdateRequestDto orderUpdateRequestDto) {
+        // 주문이 완료 되었을 때 cart에 있는 아이템 삭제
+        if(OrderState.returnValueByName(orderUpdateRequestDto.getOrderState()) > 0) {
+            Cart getCart = cartService.getCart(orderUpdateRequestDto.getUserId());
+
+            List<CartItem> cartItemList = cartItemRepository.findAllByCartId(getCart.getId());
+
+            List<Long> cartIdList = cartItemList.stream()
+                .map(CartItem::getId)
+                .collect(Collectors.toList());
+
+            cartItemRepository.deleteAllByIdIn(cartIdList);
+        }
+    }
+
     // TODO: 셀러 별로 상품을 가져오기
     // TODO: 제일 할인율이 높은 쿠폰을 각각의 셀러에게 적용하기
-
 //    public void categorizeOrder(List<OrderInfoResponseDto> list) {
 //        HashMap<Long, Integer> saveSellerIdByIdx = new HashMap<>();
 //        List<Long> sellerInfo = new ArrayList();

--- a/src/main/java/com/feelmycode/parabole/service/OrderService.java
+++ b/src/main/java/com/feelmycode/parabole/service/OrderService.java
@@ -1,16 +1,7 @@
 package com.feelmycode.parabole.service;
 
-import com.feelmycode.parabole.domain.Cart;
-import com.feelmycode.parabole.domain.CartItem;
 import com.feelmycode.parabole.domain.Order;
-import com.feelmycode.parabole.domain.User;
-import com.feelmycode.parabole.dto.OrderDeliveryUpdateRequestDto;
-import com.feelmycode.parabole.dto.OrderUpdateRequestDto;
-import com.feelmycode.parabole.enumtype.OrderState;
-import com.feelmycode.parabole.repository.CartItemRepository;
 import com.feelmycode.parabole.repository.OrderRepository;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -43,9 +34,8 @@ public class OrderService {
     }
 
     @Transactional
-    public void updateDeliveryInfo(OrderDeliveryUpdateRequestDto deliveryDto) {
-        Order order = this.getOrder(deliveryDto.getUserId());
-        order.saveDeliveryInfo(deliveryDto);
+    public void deleteOrder(Long orderId) {
+        orderRepository.deleteById(orderId);
     }
 
     public boolean isOrderEmpty(Long userId) {
@@ -59,32 +49,8 @@ public class OrderService {
         return false;
     }
 
-    @Transactional
-    public void deleteOrder(Long orderId) {
-        orderRepository.deleteById(orderId);
-    }
-
     public Order getOrderByUserId(Long userId) {
         return orderRepository.findTop1ByUserIdOrderByIdDesc(userId);
-    }
-
-    public void updateOrderState(OrderUpdateRequestDto orderUpdateRequestDto) {
-
-        Order order = this.getOrder(orderUpdateRequestDto.getUserId());
-        order.setState(orderUpdateRequestDto.getOrderState());
-
-        // 주문이 완료 되었을 때 cart에 있는 아이템 삭제
-        if(OrderState.returnValueByName(orderUpdateRequestDto.getOrderState()).getValue() != -1) {
-            Cart getCart = cartService.getCart(orderUpdateRequestDto.getUserId());
-
-            List<CartItem> cartItemList = cartItemRepository.findAllByCartId(getCart.getId());
-
-            List<Long> cartIdList = cartItemList.stream()
-                .map(CartItem::getId)
-                .collect(Collectors.toList());
-
-            cartItemRepository.deleteAllByIdIn(cartIdList);
-        }
     }
 
     // TODO: 셀러 별로 상품을 가져오기

--- a/src/main/java/com/feelmycode/parabole/service/UpdateService.java
+++ b/src/main/java/com/feelmycode/parabole/service/UpdateService.java
@@ -1,0 +1,91 @@
+package com.feelmycode.parabole.service;
+
+import com.feelmycode.parabole.domain.Cart;
+import com.feelmycode.parabole.domain.CartItem;
+import com.feelmycode.parabole.domain.Order;
+import com.feelmycode.parabole.domain.OrderInfo;
+import com.feelmycode.parabole.dto.OrderDeliveryUpdateRequestDto;
+import com.feelmycode.parabole.dto.OrderInfoRequestDto;
+import com.feelmycode.parabole.dto.OrderInfoResponseDto;
+import com.feelmycode.parabole.dto.OrderUpdateRequestDto;
+import com.feelmycode.parabole.enumtype.OrderInfoState;
+import com.feelmycode.parabole.enumtype.OrderState;
+import com.feelmycode.parabole.global.error.exception.ParaboleException;
+import com.feelmycode.parabole.repository.CartItemRepository;
+import com.feelmycode.parabole.repository.OrderInfoRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class UpdateService {
+
+    private final OrderInfoRepository orderInfoRepository;
+    private final OrderInfoService orderInfoService;
+    private final OrderService orderService;
+    private final CartItemRepository cartItemRepository;
+    private final CartService cartService;
+
+    @Transactional
+    public void updateDeliveryInfo(OrderDeliveryUpdateRequestDto deliveryDto) {
+        Order order = orderService.getOrder(deliveryDto.getUserId());
+        order.saveDeliveryInfo(deliveryDto);
+        updateOrderInfoState(new OrderInfoRequestDto(deliveryDto.getUserId(), deliveryDto.getOrderState()));
+    }
+
+    @Transactional
+    public void updateOrderInfoState(OrderInfoRequestDto orderInfoRequestDto) {
+        try {
+            OrderInfo getOrderInfo = orderInfoRepository.findById(orderInfoRequestDto.getOrderInfoId())
+                .orElseThrow(() -> new ParaboleException(HttpStatus.NOT_FOUND, "주문정보를 찾을 수 없습니다."));
+
+            getOrderInfo.setState(OrderInfoState.returnValueByName(orderInfoRequestDto.getOrderState()));
+
+            // 모든 상품이 배송완료일 때 주문이 완료되었다고 처리
+            if(orderInfoService.isDeliveryComplete(orderInfoRequestDto.getUserId())) {
+                Order order = orderService.getOrder(orderInfoRequestDto.getUserId());
+
+                List<OrderInfo> getOrderInfoList = orderInfoService.getOrderInfoListByOrderId(order.getId());
+
+                for(OrderInfo info : getOrderInfoList) {
+                    info.setState(OrderInfoState.returnValueByName(orderInfoRequestDto.getOrderState()));
+                }
+
+                this.updateOrderState(new OrderUpdateRequestDto(
+                    orderInfoRequestDto.getUserId(), OrderState.returnNameByValue(1)));
+            }
+        } catch (Exception e) {
+            throw new ParaboleException(HttpStatus.UNAUTHORIZED, "주문정보를 수정하는 중 문제가 발생했습니다.");
+        }
+    }
+
+    public void updateOrderState(OrderUpdateRequestDto orderUpdateRequestDto) {
+
+        Order order = orderService.getOrder(orderUpdateRequestDto.getUserId());
+        order.setState(orderUpdateRequestDto.getOrderState());
+
+        // 주문이 완료 되었을 때 cart에 있는 아이템 삭제
+        if(OrderState.returnValueByName(orderUpdateRequestDto.getOrderState()).getValue() != -1) {
+            Cart getCart = cartService.getCart(orderUpdateRequestDto.getUserId());
+
+            List<CartItem> cartItemList = cartItemRepository.findAllByCartId(getCart.getId());
+
+            List<OrderInfoResponseDto> orderInfoList = orderInfoService.getOrderInfoListByUserId(orderUpdateRequestDto.getUserId());
+
+            List<Long> cartIdList = cartItemList.stream()
+                .filter(item -> orderInfoList.stream().anyMatch(orderInfo -> item.getProduct().getId().equals(orderInfo.getProductId())))
+                .map(CartItem::getId)
+                .collect(Collectors.toList());
+
+            cartItemRepository.deleteAllByIdIn(cartIdList);
+        }
+    }
+
+}

--- a/src/main/java/com/feelmycode/parabole/service/UpdateService.java
+++ b/src/main/java/com/feelmycode/parabole/service/UpdateService.java
@@ -84,7 +84,7 @@ public class UpdateService {
                 .map(CartItem::getId)
                 .collect(Collectors.toList());
 
-            cartItemRepository.deleteAllByIdIn(cartIdList);
+            cartItemRepository.deleteAllById(cartIdList);
         }
     }
 


### PR DESCRIPTION
## 개요
장바구니에서 구매하거나 단건으로 구매하게 될 때 주문DB에서 일시적으로 저장한 후 처리할 수 있게 한다.

## 참고사항
OrderService와 OrderInfoService가 서로 순환참조하고 있어서 실행이 안되는 문제가 있었고 두 Service에서 Update하는 부분에서 일어났던 문제라서 UpdateService로 기능을 따로 모아서 올렸습니다. 

## 이슈번호
[#113]