### PR TITLE
[feature/coupon] 쿠폰 출력 정보 dto 수정

### DIFF
--- a/src/main/java/com/feelmycode/parabole/dto/CouponSellerResponseDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/CouponSellerResponseDto.java
@@ -21,6 +21,7 @@ public class CouponSellerResponseDto {
         private Long minPaymentAmount;
         private String detail;
         private Integer cnt;
+        private Integer remains;
 
         public CouponSellerResponseDto(Coupon coupon) {
                 this.couponId = coupon.getId();
@@ -34,6 +35,7 @@ public class CouponSellerResponseDto {
                 this.minPaymentAmount = coupon.getMinPaymentAmount();
                 this.detail = coupon.getDetail();
                 this.cnt = coupon.getCnt();
+                this.remains = coupon.getNotAssignedUserCouponList().size();
         }
 
 }


### PR DESCRIPTION
## 작업한 내용
![image](https://user-images.githubusercontent.com/46639550/196554898-e0a0e0b4-ae03-49d6-a4f5-f8cfd78af079.png)

Feat: 발급한 쿠폰의 잔여수량 출력

반환값 한개 추가했어요