### PR TITLE
[feature/event] 셀러 오피스 이벤트 스케쥴 조회 API 구현

### DIFF
--- a/src/docs/asciidoc/event.adoc
+++ b/src/docs/asciidoc/event.adoc
@@ -10,6 +10,7 @@ endif::[]
 = link:index.html[The Parabole]
 
 == 이벤트
+
 === 이벤트 등록
 
 `*Request*`
@@ -96,6 +97,20 @@ include::{resource-dir}/event-search/http-response.adoc[]
 
 include::{resource-dir}/event-search/response-fields.adoc[]
 
+=== 이벤트 스케쥴 조회
+
+`*Request*`
+
+include::{resource-dir}/event-scheduler/http-request.adoc[]
+
+`*Response*`
+
+include::{resource-dir}/event-scheduler/http-response.adoc[]
+
+`*Fields*`
+
+include::{resource-dir}/event-scheduler/response-fields.adoc[]
+
 === 이벤트 취소
 
 `*Request*`
@@ -135,6 +150,7 @@ include::{resource-dir}/eventparticipant/http-response.adoc[]
 include::{resource-dir}/eventparticipant/response-fields.adoc[]
 
 === 이벤트 응모 체크
+
 `*Request*`
 
 include::{resource-dir}/eventparticipant-check/http-request.adoc[]

--- a/src/docs/asciidoc/snippets/event-scheduler/curl-request.adoc
+++ b/src/docs/asciidoc/snippets/event-scheduler/curl-request.adoc
@@ -1,0 +1,6 @@
+[source,bash]
+----
+$ curl 'https://parabole.com:59185/api/v1/event/seller/scheduler' -i -X GET \
+    -H 'Accept: application/json, application/javascript, text/javascript, text/json' \
+    -H 'Content-Type: application/json'
+----

--- a/src/docs/asciidoc/snippets/event-scheduler/http-request.adoc
+++ b/src/docs/asciidoc/snippets/event-scheduler/http-request.adoc
@@ -1,0 +1,8 @@
+[source,http,options="nowrap"]
+----
+GET /api/v1/event/seller/scheduler HTTP/1.1
+Accept: application/json, application/javascript, text/javascript, text/json
+Content-Type: application/json
+Host: parabole.com:59185
+
+----

--- a/src/docs/asciidoc/snippets/event-scheduler/http-response.adoc
+++ b/src/docs/asciidoc/snippets/event-scheduler/http-response.adoc
@@ -1,0 +1,47 @@
+[source,http,options="nowrap"]
+----
+HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Transfer-Encoding: chunked
+Date: Mon, 07 Nov 2022 05:59:14 GMT
+Keep-Alive: timeout=60
+Connection: keep-alive
+Content-Length: 1363
+
+{
+  "success" : true,
+  "message" : "이벤트 스케쥴러 조회 성공",
+  "data" : [ {
+    "id" : 3,
+    "sellerId" : 1,
+    "createdBy" : "SELLER",
+    "type" : "FCFS",
+    "title" : "LOTTE VIBE ON",
+    "startAt" : "2022-11-11T00:00:00",
+    "endAt" : "2022-11-11T00:50:00",
+    "status" : 1,
+    "descript" : "바로 이곳이 브랜드 컬렉션",
+    "eventImage" : {
+      "eventBannerImg" : "https://contents.lotteon.com/display/dshop/43932/PE5649CB6BADF5069F7CD6125D126865125D9EDF5EFA6EAD420A61716312E2E5E/file",
+      "eventDetailImg" : "https://contents.lotteon.com/ec/public/P9E8EDB7D41DB776A67E68406C992D9DF67F36B5E94B8BA8B90A729A735707CE1/file"
+    }
+  }, {
+    "id" : 18,
+    "sellerId" : 1,
+    "createdBy" : "SELLER",
+    "type" : "FCFS",
+    "title" : "비스포크 추첨증정",
+    "startAt" : "2022-11-11T05:00:00",
+    "endAt" : "2022-11-11T05:50:00",
+    "status" : 1,
+    "descript" : "요리하다 구매고객 비스포크 추첨 증정 행사",
+    "eventImage" : {
+      "eventBannerImg" : "https://contents.lotteon.com/display/dshoplnk/12908/207/M000010/282011/P85148A5C7FABAB042D95126A67DAB7D6C14E9502B82676811754E78209CBD91B/file/dims/optimize",
+      "eventDetailImg" : "https://contents.lotteon.com/ec/public/P305972B21565D707552257D357C0863ABAC4BC7267BE647AA23ADC076B782FFA/file"
+    }
+  } ]
+}
+----

--- a/src/docs/asciidoc/snippets/event-scheduler/httpie-request.adoc
+++ b/src/docs/asciidoc/snippets/event-scheduler/httpie-request.adoc
@@ -1,0 +1,6 @@
+[source,bash]
+----
+$ http GET 'https://parabole.com:59185/api/v1/event/seller/scheduler' \
+    'Accept:application/json, application/javascript, text/javascript, text/json' \
+    'Content-Type:application/json'
+----

--- a/src/docs/asciidoc/snippets/event-scheduler/request-body.adoc
+++ b/src/docs/asciidoc/snippets/event-scheduler/request-body.adoc
@@ -1,0 +1,4 @@
+[source,options="nowrap"]
+----
+
+----

--- a/src/docs/asciidoc/snippets/event-scheduler/response-body.adoc
+++ b/src/docs/asciidoc/snippets/event-scheduler/response-body.adoc
@@ -1,0 +1,36 @@
+[source,options="nowrap"]
+----
+{
+  "success" : true,
+  "message" : "이벤트 스케쥴러 조회 성공",
+  "data" : [ {
+    "id" : 3,
+    "sellerId" : 1,
+    "createdBy" : "SELLER",
+    "type" : "FCFS",
+    "title" : "LOTTE VIBE ON",
+    "startAt" : "2022-11-11T00:00:00",
+    "endAt" : "2022-11-11T00:50:00",
+    "status" : 1,
+    "descript" : "바로 이곳이 브랜드 컬렉션",
+    "eventImage" : {
+      "eventBannerImg" : "https://contents.lotteon.com/display/dshop/43932/PE5649CB6BADF5069F7CD6125D126865125D9EDF5EFA6EAD420A61716312E2E5E/file",
+      "eventDetailImg" : "https://contents.lotteon.com/ec/public/P9E8EDB7D41DB776A67E68406C992D9DF67F36B5E94B8BA8B90A729A735707CE1/file"
+    }
+  }, {
+    "id" : 18,
+    "sellerId" : 1,
+    "createdBy" : "SELLER",
+    "type" : "FCFS",
+    "title" : "비스포크 추첨증정",
+    "startAt" : "2022-11-11T05:00:00",
+    "endAt" : "2022-11-11T05:50:00",
+    "status" : 1,
+    "descript" : "요리하다 구매고객 비스포크 추첨 증정 행사",
+    "eventImage" : {
+      "eventBannerImg" : "https://contents.lotteon.com/display/dshoplnk/12908/207/M000010/282011/P85148A5C7FABAB042D95126A67DAB7D6C14E9502B82676811754E78209CBD91B/file/dims/optimize",
+      "eventDetailImg" : "https://contents.lotteon.com/ec/public/P305972B21565D707552257D357C0863ABAC4BC7267BE647AA23ADC076B782FFA/file"
+    }
+  } ]
+}
+----

--- a/src/docs/asciidoc/snippets/event-scheduler/response-fields.adoc
+++ b/src/docs/asciidoc/snippets/event-scheduler/response-fields.adoc
@@ -1,0 +1,64 @@
+|===
+|Path|Type|Description
+
+|`+success+`
+|`+Boolean+`
+|성공여부
+
+|`+message+`
+|`+String+`
+|메세지
+
+|`+data+`
+|`+Array+`
+|응답 정보
+
+|`+data.[].id+`
+|`+Number+`
+|이벤트 번호
+
+|`+data.[].sellerId+`
+|`+Number+`
+|셀러 번호
+
+|`+data.[].createdBy+`
+|`+String+`
+|이벤트 생성자 (관리자:ADMIN / 판매자:SELLER)
+
+|`+data.[].type+`
+|`+String+`
+|이벤트 유형 (RAFFLE:추첨 / FCFS:선착순)
+
+|`+data.[].title+`
+|`+String+`
+|이벤트 제목
+
+|`+data.[].startAt+`
+|`+String+`
+|이벤트 시작 일시 (yyyy-MM-dd'T'HH:mm:ss)
+
+|`+data.[].endAt+`
+|`+String+`
+|이벤트 종료 일시 (yyyy-MM-dd'T'HH:mm:ss)
+
+|`+data.[].status+`
+|`+Number+`
+|이벤트 진행 상태 (0: 진행전 / 1: 진행중 / 2: 종료)
+
+|`+data.[].descript+`
+|`+String+`
+|이벤트 상세 설명
+
+|`+data.[].eventImage+`
+|`+Object+`
+|이벤트 이미지(URL) 정보
+
+|`+data.[].eventImage.eventBannerImg+`
+|`+String+`
+|이벤트 배너 이미지(URL)
+
+|`+data.[].eventImage.eventDetailImg+`
+|`+String+`
+|이벤트 상세 이미지(URL)
+
+|===

--- a/src/main/java/com/feelmycode/parabole/controller/EventController.java
+++ b/src/main/java/com/feelmycode/parabole/controller/EventController.java
@@ -87,6 +87,12 @@ public class EventController {
         return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "이벤트 리스트 조회 성공", response);
     }
 
+    @GetMapping("/seller/scheduler")
+    public ResponseEntity<ParaboleResponse> getEventScheduler() {
+        List<EventSearchResponseDto> response = eventService.getEventsMonthAfter();
+        return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "이벤트 스케쥴러 조회 성공", response);
+    }
+
     @DeleteMapping("/{eventId}")
     public ResponseEntity<ParaboleResponse> cancelEvent(@PathVariable("eventId") Long eventId) {
         try {

--- a/src/main/java/com/feelmycode/parabole/service/EventService.java
+++ b/src/main/java/com/feelmycode/parabole/service/EventService.java
@@ -22,6 +22,7 @@ import com.feelmycode.parabole.repository.SellerRepository;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.persistence.criteria.CriteriaBuilder.In;
@@ -181,7 +182,20 @@ public class EventService {
         return eventRepository.findAllByIsDeleted(false);
     }
 
-    // TODO : 이벤트 수정
+    /**
+     * 이벤트 조회 (셀러 오피스 이벤트 목록 조회용)
+     */
+    public List<EventSearchResponseDto> getEventsMonthAfter() {
+        LocalDateTime nowDate = LocalDateTime.now();
+        LocalDateTime monthAfterDate = nowDate.plusMonths(1L);
+        return eventRepository.findAllByStartAtBetweenAndIsDeleted(nowDate,
+                monthAfterDate, false)
+            .stream()
+            .filter(event -> event.getType().equals("FCFS"))
+            .sorted(Comparator.comparing(Event::getStartAt))
+            .map(EventSearchResponseDto::new)
+            .collect(Collectors.toList());
+    }
 
     /**
      * 이벤트 취소

--- a/src/test/java/com/feelmycode/parabole/controller/EventControllerTest.java
+++ b/src/test/java/com/feelmycode/parabole/controller/EventControllerTest.java
@@ -481,6 +481,54 @@ public class EventControllerTest {
     }
 
     @Test
+    @DisplayName("이벤트 스케쥴 조회")
+    public void getEventsforScheduler() {
+
+        // when
+        Response resp = given(this.spec)
+            .accept(ContentType.JSON)
+            .contentType(ContentType.JSON)
+            .port(port)
+            .filter(document("event-scheduler",
+                preprocessRequest(modifyUris()
+                        .scheme("https")
+                        .host("parabole.com"),
+                    prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                    fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공여부"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("메세지"),
+                    fieldWithPath("data").type(JsonFieldType.ARRAY).description("응답 정보"),
+                    fieldWithPath("data.[].id").type(JsonFieldType.NUMBER).description("이벤트 번호"),
+                    fieldWithPath("data.[].sellerId").type(JsonFieldType.NUMBER)
+                        .description("셀러 번호"),
+                    fieldWithPath("data.[].createdBy").type(JsonFieldType.STRING)
+                        .description("이벤트 생성자 (관리자:ADMIN / 판매자:SELLER)"),
+                    fieldWithPath("data.[].type").type(JsonFieldType.STRING).description("이벤트 유형 (RAFFLE:추첨 / FCFS:선착순)"),
+                    fieldWithPath("data.[].title").type(JsonFieldType.STRING).description("이벤트 제목"),
+                    fieldWithPath("data.[].startAt").type(JsonFieldType.STRING)
+                        .description("이벤트 시작 일시 (yyyy-MM-dd'T'HH:mm:ss)"),
+                    fieldWithPath("data.[].endAt").type(JsonFieldType.STRING)
+                        .description("이벤트 종료 일시 (yyyy-MM-dd'T'HH:mm:ss)"),
+                    fieldWithPath("data.[].status").type(JsonFieldType.NUMBER)
+                        .description("이벤트 진행 상태 (0: 진행전 / 1: 진행중 / 2: 종료)"),
+                    fieldWithPath("data.[].descript").type(JsonFieldType.STRING)
+                        .description("이벤트 상세 설명"),
+                    fieldWithPath("data.[].eventImage").type(JsonFieldType.OBJECT)
+                        .description("이벤트 이미지(URL) 정보"),
+                    fieldWithPath("data.[].eventImage.eventBannerImg").type(JsonFieldType.STRING)
+                        .description("이벤트 배너 이미지(URL)"),
+                    fieldWithPath("data.[].eventImage.eventDetailImg").type(JsonFieldType.STRING)
+                        .description("이벤트 상세 이미지(URL)")
+                )
+            ))
+            .when().get(BASIC_PATH + "/seller/scheduler");
+
+        Assertions.assertEquals(HttpStatus.OK.value(), resp.statusCode());
+
+    }
+
+    @Test
     @DisplayName("이벤트 취소")
     public void deleteEvent() {
 


### PR DESCRIPTION
## 개요
셀러 오피스에서 이벤트 스케쥴 조회를 위한 api를 구현했습니다.

## 작업한 내용
- 현재 날짜를 기준으로 _시작일시가_ **한달** 이내, _이벤트 유형_이 **선착순(FCFS)**인 이벤트 목록을 조회하는 API를 구현했습니다. 

## 리뷰 가이드 
- 현재는 파라미터가 없는 API지만 날짜를 입력 받아서 계산할 수 있도록 수정하는 것이 나을까요? 의견 바랍니다~

## 이슈번호
[#98] [#185]