### PR TITLE
[feature/eventmsa] 이벤트서버 분리를 위한 초기 세팅 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,15 +4,21 @@ buildscript {
     }
 }
 plugins {
-	id 'org.springframework.boot' version '2.7.3'
-	id 'io.spring.dependency-management' version '1.0.13.RELEASE'
-	id 'java'
-	id 'org.asciidoctor.jvm.convert' version "3.3.2"
+    id 'org.springframework.boot' version '2.7.3'
+    id 'io.spring.dependency-management' version '1.0.13.RELEASE'
+    id 'java'
+    id 'org.asciidoctor.jvm.convert' version "3.3.2"
 }
 
 group = 'com.feelmycode.parabole'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '17'
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:2021.0.3"
+    }
+}
 
 configurations {
     asciidoctorExtensions
@@ -36,6 +42,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'mysql:mysql-connector-java'
     implementation 'junit:junit:4.13.1'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.3'
@@ -56,12 +64,13 @@ dependencies {
 }
 
 ext {
+    set('springCloudVersion', "2021.0.4")
     snippetsDir = file("./src/main/resources/snippets")
 }
 
 test {
     outputs.dir snippetsDir
-    useJUnitPlatform{
+    useJUnitPlatform {
         includeEngines 'junit-vintage'
     }
 }

--- a/src/main/java/com/feelmycode/parabole/ParaboleApplication.java
+++ b/src/main/java/com/feelmycode/parabole/ParaboleApplication.java
@@ -2,10 +2,14 @@ package com.feelmycode.parabole;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableDiscoveryClient
+@EnableFeignClients
 public class ParaboleApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/feelmycode/parabole/controller/CouponController.java
+++ b/src/main/java/com/feelmycode/parabole/controller/CouponController.java
@@ -7,6 +7,7 @@ import com.feelmycode.parabole.domain.UserCoupon;
 import com.feelmycode.parabole.dto.CouponAssignRequestDto;
 import com.feelmycode.parabole.dto.CouponCreateRequestDto;
 import com.feelmycode.parabole.dto.CouponCreateResponseDto;
+import com.feelmycode.parabole.dto.CouponDto;
 import com.feelmycode.parabole.dto.CouponInfoResponseDto;
 import com.feelmycode.parabole.dto.CouponSellerResponseDto;
 import com.feelmycode.parabole.dto.CouponUseAndAssignRequestDto;
@@ -136,6 +137,13 @@ public class CouponController {
         CouponInfoResponseDto response = couponService.getCouponInfo(couponSNo);
         return ParaboleResponse.CommonResponse(HttpStatus.OK,
             true, "쿠폰 정보 반환", response);
+    }
+
+    @GetMapping("/data")
+    public CouponDto getCouponData(@RequestParam Long couponId){
+        Coupon coupon = couponService.getCouponById(couponId);
+        CouponDto couponDto = new CouponDto(coupon.getId(), coupon.getDetail(), coupon.getDiscountValue(), coupon.getExpiresAt());
+        return couponDto;
     }
 
     @PostMapping("/user/use")

--- a/src/main/java/com/feelmycode/parabole/controller/ProductController.java
+++ b/src/main/java/com/feelmycode/parabole/controller/ProductController.java
@@ -1,8 +1,10 @@
 package com.feelmycode.parabole.controller;
 
+import com.feelmycode.parabole.domain.Product;
 import com.feelmycode.parabole.dto.ProductDetailListResponseDto;
 import com.feelmycode.parabole.dto.ProductDto;
 import com.feelmycode.parabole.dto.ProductRequestDto;
+import com.feelmycode.parabole.dto.ProductResponseDto;
 import com.feelmycode.parabole.global.api.ParaboleResponse;
 import com.feelmycode.parabole.global.error.exception.ParaboleException;
 import com.feelmycode.parabole.global.util.StringUtil;
@@ -60,6 +62,14 @@ public class ProductController {
             getProductName, getCategory, pageable);
 
         return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "상품 전시", response);
+    }
+
+    @GetMapping("/data")
+    public ProductResponseDto getProducts(@RequestParam Long productId) {
+        Product response = productService.getProduct(productId);
+        ProductResponseDto dto = new ProductResponseDto(response.getId(), response.getName(),
+            response.getThumbnailImg());
+        return dto;
     }
 
     @PostMapping

--- a/src/main/java/com/feelmycode/parabole/dto/CouponDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/CouponDto.java
@@ -1,0 +1,21 @@
+package com.feelmycode.parabole.dto;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class CouponDto {
+
+    private Long couponId;
+    private String couponDetail;
+    private Integer couponDiscountValue;
+    private LocalDateTime expiresAt;
+
+    public CouponDto(Long couponId, String couponDetail, Integer couponDiscountValue,
+        LocalDateTime expiresAt) {
+        this.couponId = couponId;
+        this.couponDetail = couponDetail;
+        this.couponDiscountValue = couponDiscountValue;
+        this.expiresAt = expiresAt;
+    }
+}

--- a/src/main/java/com/feelmycode/parabole/dto/ProductResponseDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/ProductResponseDto.java
@@ -1,0 +1,18 @@
+package com.feelmycode.parabole.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ProductResponseDto {
+
+    private Long productId;
+    private String productName;
+    private String productImg;
+
+    public ProductResponseDto(Long productId, String productName, String productImg) {
+        this.productId = productId;
+        this.productName = productName;
+        this.productImg = productImg;
+    }
+
+}


### PR DESCRIPTION
## 개요
Parabole 마켓 서버에서 이벤트 서버를 분리하기 위한 초기 세팅입니다.
@choihyeongjun 이 작업하였습니다.

## 작업한 내용
- 유레카서버,  페인 클라이언트 구동을 위한 의존성을 추가했습니다.
- 이벤트 서버에서 상품 및 쿠폰 정보 조회를 위한 페인 클라이언트 api 추가했습니다.

## 리뷰 가이드 
- 아직 이벤트 서버는 배포가 되지 않아서 로컬에서만 테스트해주세요
- (자세한 실행 가이드는 노션에 적어두겠습니다.)
