### PR TITLE
[feature/migration] 이벤트 서버에서 이벤트 등록 및 취소 시 경품 수량을 처리할 수 있는 API 구현

### DIFF
--- a/src/main/java/com/feelmycode/parabole/controller/CouponController.java
+++ b/src/main/java/com/feelmycode/parabole/controller/CouponController.java
@@ -31,6 +31,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -157,5 +159,12 @@ public class CouponController {
 
         couponService.useUserCoupon(dto.getCouponSNo(), userId);
         return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "쿠폰이 정상적으로 사용되었습니다.");
+    }
+
+    @PatchMapping("/{couponId}/stock/{stock}")
+    public Boolean setProductRemains(@PathVariable("couponId") Long couponId,
+        @PathVariable("stock") Integer stock) {
+        log.info("Set Coupon Remains By Event Server : {} ", couponId);
+        return couponService.setCouponStock(couponId, stock);
     }
 }

--- a/src/main/java/com/feelmycode/parabole/controller/CouponController.java
+++ b/src/main/java/com/feelmycode/parabole/controller/CouponController.java
@@ -12,6 +12,7 @@ import com.feelmycode.parabole.dto.CouponInfoResponseDto;
 import com.feelmycode.parabole.dto.CouponSellerResponseDto;
 import com.feelmycode.parabole.dto.CouponUseAndAssignRequestDto;
 import com.feelmycode.parabole.dto.CouponUserResponseDto;
+import com.feelmycode.parabole.enumtype.CouponType;
 import com.feelmycode.parabole.global.api.ParaboleResponse;
 import com.feelmycode.parabole.global.error.exception.NoDataException;
 import com.feelmycode.parabole.global.error.exception.ParaboleException;
@@ -54,7 +55,7 @@ public class CouponController {
 
     @PostMapping("/create")
     public ResponseEntity<ParaboleResponse> addCoupon(@RequestAttribute Long userId,
-                                    @RequestBody CouponCreateRequestDto dto) {
+        @RequestBody CouponCreateRequestDto dto) {
 
         /** addCoupon, addUserCoupon 이 모두 발생한다. */
         CouponCreateResponseDto response = couponService.addCoupon(userId, dto);
@@ -100,7 +101,8 @@ public class CouponController {
 
         Pageable getPageable = PageRequest.of(DEFAULT_PAGE, DEFAULT_SIZE);
 
-        Page<CouponSellerResponseDto> sellerCouponList = couponService.getSellerCouponListBySellerId(sellerId);
+        Page<CouponSellerResponseDto> sellerCouponList = couponService.getSellerCouponListBySellerId(
+            sellerId);
         return ParaboleResponse.CommonResponse(HttpStatus.OK,
             true, "셀러 쿠폰 목록", sellerCouponList);
     }
@@ -120,13 +122,14 @@ public class CouponController {
 
         Pageable getPageable = PageRequest.of(DEFAULT_PAGE, DEFAULT_SIZE);
 
-        if(userService.isSeller(userId)){
+        if (userService.isSeller(userId)) {
             Page<CouponUserResponseDto> userCouponList = couponService.getUserCouponList(userId);
             return ParaboleResponse.CommonResponse(HttpStatus.OK,
                 true, "유저 쿠폰 목록", userCouponList);
         }
         Seller seller = sellerService.getSellerByUserId(userId);
-        Page<CouponSellerResponseDto> sellerCouponList = couponService.getSellerCouponList(seller.getId());
+        Page<CouponSellerResponseDto> sellerCouponList = couponService.getSellerCouponList(
+            seller.getId());
         return ParaboleResponse.CommonResponse(HttpStatus.OK,
             true, "셀러 쿠폰 목록", sellerCouponList);
     }
@@ -140,9 +143,11 @@ public class CouponController {
     }
 
     @GetMapping("/data")
-    public CouponDto getCouponData(@RequestParam Long couponId){
+    public CouponDto getCouponData(@RequestParam Long couponId) {
         Coupon coupon = couponService.getCouponById(couponId);
-        CouponDto couponDto = new CouponDto(coupon.getId(), coupon.getDetail(), coupon.getDiscountValue(), coupon.getExpiresAt());
+        CouponDto couponDto = new CouponDto(coupon.getId(), coupon.getName(),
+            CouponType.returnNameByValue(coupon.getType().getValue()), coupon.getDetail(),
+            coupon.getDiscountValue(), coupon.getExpiresAt());
         return couponDto;
     }
 

--- a/src/main/java/com/feelmycode/parabole/controller/ProductController.java
+++ b/src/main/java/com/feelmycode/parabole/controller/ProductController.java
@@ -15,6 +15,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -91,4 +93,10 @@ public class ProductController {
         return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "판매자가 등록한 상품 목록", response);
     }
 
+    @PatchMapping("/{productId}/stock/{stock}")
+    public Boolean setProductRemains(@PathVariable("productId") Long productId,
+        @PathVariable("stock") Integer stock) {
+        log.info("Set Product Remains By Event Server : {} ", productId);
+        return productService.setProductRemains(productId, Long.valueOf(stock));
+    }
 }

--- a/src/main/java/com/feelmycode/parabole/domain/Coupon.java
+++ b/src/main/java/com/feelmycode/parabole/domain/Coupon.java
@@ -149,10 +149,14 @@ public class Coupon extends BaseEntity implements Serializable {
     }
 
     public void setCouponForEvent(Integer inputStock) {
-        userCoupons.stream().limit(inputStock).forEach(UserCoupon::setEventEnrolled);
+        userCoupons.stream().limit(inputStock)
+            .filter(userCoupon -> userCoupon.getUseState().equals(CouponUseState.NotUsed))
+            .forEach(UserCoupon::setEventEnrolled);
     }
 
     public void cancelCouponEvent(Integer inputStock) {
-        userCoupons.stream().limit(inputStock).forEach(UserCoupon::setNotUsed);
+        userCoupons.stream().limit(inputStock)
+            .filter(userCoupon -> userCoupon.getUseState().equals(CouponUseState.EventEnrolled))
+            .forEach(UserCoupon::setNotUsed);
     }
 }

--- a/src/main/java/com/feelmycode/parabole/dto/CouponDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/CouponDto.java
@@ -7,13 +7,17 @@ import lombok.Getter;
 public class CouponDto {
 
     private Long couponId;
+    private String couponName;
+    private String couponType;
     private String couponDetail;
     private Integer couponDiscountValue;
     private LocalDateTime expiresAt;
 
-    public CouponDto(Long couponId, String couponDetail, Integer couponDiscountValue,
+    public CouponDto(Long couponId, String couponName, String couponType, String couponDetail, Integer couponDiscountValue,
         LocalDateTime expiresAt) {
         this.couponId = couponId;
+        this.couponName = couponName;
+        this.couponType = couponType;
         this.couponDetail = couponDetail;
         this.couponDiscountValue = couponDiscountValue;
         this.expiresAt = expiresAt;

--- a/src/main/java/com/feelmycode/parabole/service/CouponService.java
+++ b/src/main/java/com/feelmycode/parabole/service/CouponService.java
@@ -72,6 +72,22 @@ public class CouponService {
 //        userCoupon.setUser(user);
 //    }
 
+    @Transactional
+    public Boolean setCouponStock(Long couponId, Integer stock) {
+        Coupon getCoupon = this.getCouponById(couponId);
+        try {
+            if (stock < 0) {
+                getCoupon.setCouponForEvent(stock * -1);
+            } else {
+                getCoupon.cancelCouponEvent(stock);
+            }
+            couponRepository.save(getCoupon);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+        return true;
+    }
+
     public Coupon getCouponById(Long couponId) {
         return couponRepository.findById(couponId).orElseThrow(() -> new NoDataException());
     }

--- a/src/main/java/com/feelmycode/parabole/service/ProductService.java
+++ b/src/main/java/com/feelmycode/parabole/service/ProductService.java
@@ -10,6 +10,7 @@ import com.feelmycode.parabole.global.error.exception.ParaboleException;
 import com.feelmycode.parabole.repository.ProductRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -19,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Slf4j
 public class ProductService {
 
     private final ProductRepository productRepository;
@@ -48,6 +50,22 @@ public class ProductService {
         productRepository.save(getProduct);
         return product.getId();
     }
+
+    @Transactional
+    public Boolean setProductRemains(Long productId, Long stock) {
+        Product getProduct = this.getProduct(productId);
+        try {
+            if (stock < 0) {
+                getProduct.removeRemains(stock * -1);
+            } else {
+                getProduct.addRemains(stock);
+            }
+            productRepository.save(getProduct);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+        return true;
+    };
 
     public Product getProduct(Long productId) {
         return productRepository.findById(productId)


### PR DESCRIPTION
## 개요
마켓서버에서 이벤트 서비스 분리 작업 중, **이벤트를 등록 혹은 취소할 때 경품 (상품/쿠폰) 수량을 원복하기 위한 API**를 구현했습니다.

## 작업한 내용
- 상품 수량 원복처리
    * 이벤트 등록/취소 시 수량 처리는 같은 API를 사용하고, `stock` 0 이상인지 체크해 등록과 취소를 구분
    * `stock < 0` 인 경우 : 이벤트 등록, 기존 상품의 수량에서 stock만큼 감소
    * `stock > 0` 인 경우 : 이벤트 취소, 기존 상품의 수량에서 stock만큼 증가

- 쿠폰 수량 원복처리
    * 상품 수량 처리 api와 유사
    * `stock` 만큼 UserCoupon을 `NotUsed` / `EventEnrolled` 로 상태를 변경

## 기타 내용
**MSA 구조에서 자원을 주고받을 때도 정의해둔 Response (ParaboleResponse)를 사용해야 하는지 궁금합니다!**
알려주세요~!

@choihyeongjun 제가 저희 시스템 카프카 구조에 대해서 잘 몰라서 그런데,, 이벤트가 취소되면 메시징 큐에 넣어둔담에 마켓서버에서 이거 읽고 취소됐다는 내용 확인되면 로직 수행할수 있도록..할 수 있을까요?!
## 앞으로 추가 예정 내용
- 이벤트 등록시 이미지 Aws S3에 업로드하는 부분 이관... 🥲

## 이슈번호
[#204]