### PR TITLE
[feature/couponfix] 쿠폰 생성에 sellerId 사용

### DIFF
--- a/src/main/java/com/feelmycode/parabole/controller/CouponController.java
+++ b/src/main/java/com/feelmycode/parabole/controller/CouponController.java
@@ -49,7 +49,7 @@ public class CouponController {
     private final static int DEFAULT_PAGE = 0;
     private final static int DEFAULT_SIZE = 20;
 
-    @PostMapping("/create")
+    @PostMapping("/new")
     public ResponseEntity<ParaboleResponse> addCoupon(@RequestAttribute Long sellerId,
                                     @RequestBody CouponCreateRequestDto dto) {
 

--- a/src/main/java/com/feelmycode/parabole/controller/CouponController.java
+++ b/src/main/java/com/feelmycode/parabole/controller/CouponController.java
@@ -24,8 +24,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -52,11 +50,11 @@ public class CouponController {
     private final static int DEFAULT_SIZE = 20;
 
     @PostMapping("/create")
-    public ResponseEntity<ParaboleResponse> addCoupon(@RequestAttribute Long userId,
+    public ResponseEntity<ParaboleResponse> addCoupon(@RequestAttribute Long sellerId,
                                     @RequestBody CouponCreateRequestDto dto) {
 
         /** addCoupon, addUserCoupon 이 모두 발생한다. */
-        CouponCreateResponseDto response = couponService.addCoupon(userId, dto);
+        CouponCreateResponseDto response = couponService.addCoupon(sellerId, dto);
         return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "쿠폰 등록 성공", response);
     }
 

--- a/src/main/java/com/feelmycode/parabole/controller/CouponController.java
+++ b/src/main/java/com/feelmycode/parabole/controller/CouponController.java
@@ -1,7 +1,6 @@
 package com.feelmycode.parabole.controller;
 
 import com.feelmycode.parabole.domain.Coupon;
-import com.feelmycode.parabole.domain.Seller;
 import com.feelmycode.parabole.domain.User;
 import com.feelmycode.parabole.domain.UserCoupon;
 import com.feelmycode.parabole.dto.CouponAssignRequestDto;
@@ -98,8 +97,6 @@ public class CouponController {
     @GetMapping("/seller/list")
     public ResponseEntity<ParaboleResponse> getSellerCouponList(@RequestAttribute Long sellerId) {
 
-        Pageable getPageable = PageRequest.of(DEFAULT_PAGE, DEFAULT_SIZE);
-
         Page<CouponSellerResponseDto> sellerCouponList = couponService.getSellerCouponListBySellerId(sellerId);
         return ParaboleResponse.CommonResponse(HttpStatus.OK,
             true, "셀러 쿠폰 목록", sellerCouponList);
@@ -108,28 +105,24 @@ public class CouponController {
     @GetMapping("/user/list")
     public ResponseEntity<ParaboleResponse> getUserCouponList(@RequestAttribute Long userId) {
 
-        Pageable getPageable = PageRequest.of(DEFAULT_PAGE, DEFAULT_SIZE);
-
         Page<CouponUserResponseDto> userCouponList = couponService.getUserCouponList(userId);
         return ParaboleResponse.CommonResponse(HttpStatus.OK,
             true, "유저 쿠폰 목록", userCouponList);
     }
 
-    @GetMapping("/list")
-    public ResponseEntity<ParaboleResponse> getCouponList(@RequestAttribute Long userId) {
-
-        Pageable getPageable = PageRequest.of(DEFAULT_PAGE, DEFAULT_SIZE);
-
-        if(userService.isSeller(userId)){
-            Page<CouponUserResponseDto> userCouponList = couponService.getUserCouponList(userId);
-            return ParaboleResponse.CommonResponse(HttpStatus.OK,
-                true, "유저 쿠폰 목록", userCouponList);
-        }
-        Seller seller = sellerService.getSellerByUserId(userId);
-        Page<CouponSellerResponseDto> sellerCouponList = couponService.getSellerCouponList(seller.getId());
-        return ParaboleResponse.CommonResponse(HttpStatus.OK,
-            true, "셀러 쿠폰 목록", sellerCouponList);
-    }
+//    @GetMapping("/list")
+//    public ResponseEntity<ParaboleResponse> getCouponList(@RequestAttribute Long userId) {
+//
+//        if(userService.isSeller(userId)){
+//            Seller seller = sellerService.getSellerByUserId(userId);
+//            Page<CouponSellerResponseDto> sellerCouponList = couponService.getSellerCouponList(seller.getId());
+//            return ParaboleResponse.CommonResponse(HttpStatus.OK,
+//                true, "셀러 쿠폰 목록", sellerCouponList);
+//        }
+//        Page<CouponUserResponseDto> userCouponList = couponService.getUserCouponList(userId);
+//        return ParaboleResponse.CommonResponse(HttpStatus.OK,
+//            true, "유저 쿠폰 목록", userCouponList);
+//    }
 
     @GetMapping("/info")
     public ResponseEntity<ParaboleResponse> getCouponInfo(@RequestParam String couponSNo) {

--- a/src/main/java/com/feelmycode/parabole/domain/Coupon.java
+++ b/src/main/java/com/feelmycode/parabole/domain/Coupon.java
@@ -1,9 +1,7 @@
 package com.feelmycode.parabole.domain;
 
-import com.feelmycode.parabole.domain.Seller;
 import com.feelmycode.parabole.enumtype.CouponType;
 import com.feelmycode.parabole.enumtype.CouponUseState;
-import com.feelmycode.parabole.service.SellerService;
 import com.sun.istack.NotNull;
 import java.io.Serializable;
 import java.time.LocalDateTime;
@@ -62,14 +60,6 @@ public class Coupon extends BaseEntity implements Serializable {
     @NotNull
     private LocalDateTime expiresAt;
 
-    @Column(name = "coupon_max_discount_amount")
-    @NotNull
-    private Long maxDiscountAmount;
-
-    @Column(name = "coupon_min_payment_amount")
-    @NotNull
-    private Long minPaymentAmount;
-
     @Column(name = "coupon_details")
     @NotNull
     private String detail;
@@ -81,13 +71,8 @@ public class Coupon extends BaseEntity implements Serializable {
     @OneToMany(mappedBy = "coupon", cascade = CascadeType.ALL)
     private List<UserCoupon> userCoupons = new ArrayList<>();
 
-//    public void setSeller(Seller seller) {
-//        this.seller = seller;
-//    }
-
     public Coupon(String name, Seller seller, CouponType type, Integer discountValue,
-        LocalDateTime validAt, LocalDateTime expiresAt,
-        Long maxDiscountAmount, Long minPaymentAmount, String detail, Integer cnt) {
+        LocalDateTime validAt, LocalDateTime expiresAt, String detail, Integer cnt) {
 
         this.name = name;
         this.seller = seller;
@@ -95,8 +80,6 @@ public class Coupon extends BaseEntity implements Serializable {
         this.discountValue = discountValue;
         this.validAt = validAt;
         this.expiresAt = expiresAt;
-        this.maxDiscountAmount = maxDiscountAmount;
-        this.minPaymentAmount = minPaymentAmount;
         this.detail = detail;
         this.cnt = cnt;
     }

--- a/src/main/java/com/feelmycode/parabole/dto/CouponCreateRequestDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/CouponCreateRequestDto.java
@@ -11,8 +11,6 @@ public class CouponCreateRequestDto {
         private Integer discountValue;
         private LocalDateTime validAt;
         private LocalDateTime expiresAt;
-        private Long maxDiscountAmount;
-        private Long minPaymentAmount;
         private String detail;
         private Integer cnt;
 

--- a/src/main/java/com/feelmycode/parabole/dto/CouponCreateResponseDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/CouponCreateResponseDto.java
@@ -6,14 +6,14 @@ import lombok.Getter;
 public class CouponCreateResponseDto {
 
     private String couponName;
-    private String sellerName;
+    private String sellerStorename;
     private String type;
     private Integer cnt;
 
-    public CouponCreateResponseDto(String couponName, String sellerName, String type,
+    public CouponCreateResponseDto(String couponName, String sellerStorename, String type,
         Integer cnt) {
         this.couponName = couponName;
-        this.sellerName = sellerName;
+        this.sellerStorename = sellerStorename;
         this.type = type;
         this.cnt = cnt;
     }

--- a/src/main/java/com/feelmycode/parabole/dto/CouponSellerResponseDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/CouponSellerResponseDto.java
@@ -14,11 +14,7 @@ public class CouponSellerResponseDto {
         private String name;
         private Integer type;
         private Integer discountValue;
-        private LocalDateTime createdAt;
-        private LocalDateTime validAt;
         private LocalDateTime expiresAt;
-        private Long maxDiscountAmount;
-        private Long minPaymentAmount;
         private String detail;
         private Integer cnt;
         private Integer remains;
@@ -28,11 +24,7 @@ public class CouponSellerResponseDto {
                 this.name = coupon.getName();
                 this.type = coupon.getType().getValue();
                 this.discountValue = coupon.getDiscountValue();
-                this.createdAt = coupon.getCreatedAt();
-                this.validAt = coupon.getValidAt();
                 this.expiresAt = coupon.getExpiresAt();
-                this.maxDiscountAmount = coupon.getMaxDiscountAmount();
-                this.minPaymentAmount = coupon.getMinPaymentAmount();
                 this.detail = coupon.getDetail();
                 this.cnt = coupon.getCnt();
                 this.remains = coupon.getNotAssignedUserCouponList().size();

--- a/src/main/java/com/feelmycode/parabole/dto/CouponUserResponseDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/CouponUserResponseDto.java
@@ -2,9 +2,7 @@ package com.feelmycode.parabole.dto;
 
 import com.feelmycode.parabole.domain.Coupon;
 import com.feelmycode.parabole.domain.UserCoupon;
-import com.feelmycode.parabole.enumtype.CouponType;
 import java.time.LocalDateTime;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
@@ -18,12 +16,7 @@ public class CouponUserResponseDto {
         private Integer discountValue;
         private String useState;
         private LocalDateTime useDate;
-        private LocalDateTime acquiredDate;
-        private LocalDateTime validAt;
         private LocalDateTime expiresAt;
-
-        private Long maxDiscountAmount;
-        private Long minPaymentAmount;
 
         public CouponUserResponseDto(Coupon coupon, UserCoupon userCoupon, String sellerName) {
 
@@ -33,12 +26,8 @@ public class CouponUserResponseDto {
                 this.type = coupon.getType().getName();
                 this.discountValue = coupon.getDiscountValue();
                 this.useState = userCoupon.getUseState().getState();
-                this.acquiredDate = userCoupon.getAcquiredDate();
                 this.useDate = userCoupon.getUseDate();
-                this.validAt = coupon.getValidAt();
                 this.expiresAt = coupon.getExpiresAt();
-                this.maxDiscountAmount = coupon.getMaxDiscountAmount();
-                this.minPaymentAmount = coupon.getMinPaymentAmount();
         }
 
 }

--- a/src/main/java/com/feelmycode/parabole/service/CouponService.java
+++ b/src/main/java/com/feelmycode/parabole/service/CouponService.java
@@ -51,7 +51,7 @@ public class CouponService {
             .orElseThrow(() -> new NoDataException());
 
         Coupon coupon = new Coupon(dto.getName(), user.getSeller(), CouponType.returnNameToValue(dto.getType()), dto.getDiscountValue(), dto.getValidAt(),
-            dto.getExpiresAt(), dto.getMaxDiscountAmount(), dto.getMinPaymentAmount(), dto.getDetail(), dto.getCnt());
+            dto.getExpiresAt(), dto.getDetail(), dto.getCnt());
 
         couponRepository.save(coupon);
 

--- a/src/main/java/com/feelmycode/parabole/service/CouponService.java
+++ b/src/main/java/com/feelmycode/parabole/service/CouponService.java
@@ -14,6 +14,7 @@ import com.feelmycode.parabole.dto.CouponUserResponseDto;
 import com.feelmycode.parabole.enumtype.CouponType;
 import com.feelmycode.parabole.enumtype.CouponUseState;
 import com.feelmycode.parabole.global.error.exception.NoDataException;
+import com.feelmycode.parabole.global.error.exception.NotSellerException;
 import com.feelmycode.parabole.global.error.exception.ParaboleException;
 import com.feelmycode.parabole.repository.CouponRepository;
 import com.feelmycode.parabole.repository.SellerRepository;
@@ -46,11 +47,11 @@ public class CouponService {
     private final UserCouponRepository userCouponRepository;
 
     @Transactional
-    public CouponCreateResponseDto addCoupon(Long userId, @NotNull CouponCreateRequestDto dto) {
-        User user = userRepository.findById(userId)
-            .orElseThrow(() -> new NoDataException());
+    public CouponCreateResponseDto addCoupon(Long sellerId, @NotNull CouponCreateRequestDto dto) {
 
-        Coupon coupon = new Coupon(dto.getName(), user.getSeller(), CouponType.returnNameToValue(dto.getType()), dto.getDiscountValue(), dto.getValidAt(),
+        Seller seller = sellerRepository.findById(sellerId).orElseThrow(() -> new NotSellerException());
+
+        Coupon coupon = new Coupon(dto.getName(), seller, CouponType.returnNameToValue(dto.getType()), dto.getDiscountValue(), dto.getValidAt(),
             dto.getExpiresAt(), dto.getDetail(), dto.getCnt());
 
         couponRepository.save(coupon);
@@ -58,7 +59,7 @@ public class CouponService {
         for (int i = 0; i < dto.getCnt(); i++) {
             coupon.addUserCoupon(new UserCoupon(coupon));
         }
-        return new CouponCreateResponseDto(coupon.getName(), user.getUsername(), coupon.getType().getName(), coupon.getCnt());
+        return new CouponCreateResponseDto(coupon.getName(), seller.getStoreName(), coupon.getType().getName(), coupon.getCnt());
     }
 
 //    public void giveoutUserCoupon(String couponSNo, Long userId) {


### PR DESCRIPTION
## 작업한 내용

프로젝트 진행 단계 초반에는 userId 를 받을지 sellerId 를 받을지 
모두 알지 못하는 상태에서 작업했습니다.

sellerId 를 받을 수 있도록 로그인을 구성하였기 때문에 쿠폰 생성에 sellerId 사용하도록 API 를 수정해서 

백엔드에서 불필요한 find sellerId by userId 단계를 없애주었습니다.
