### PR TITLE
[feature/order] 주문 정보 가져오는 부분 수정 및 enum에서 Integer값을 가져오고 저장하도록 변경

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -34,3 +34,7 @@ link:event.html[Go To Event Page]
 == User (사용자)
 
 link:user.html[Go To Event Page]
+
+== Coupon (쿠폰)
+
+link:coupon.html[Go To Coupon Page]

--- a/src/main/java/com/feelmycode/parabole/controller/CouponController.java
+++ b/src/main/java/com/feelmycode/parabole/controller/CouponController.java
@@ -171,7 +171,8 @@ public class CouponController {
     }
 
     @GetMapping
-    public ResponseEntity<ParaboleResponse> getCouponGroupBySeller(@RequestAttribute Long userId, @RequestBody CouponRequestDto couponRequestDto) {
+    public ResponseEntity<ParaboleResponse> getCouponGroupBySeller(@RequestAttribute Long userId, @RequestParam Long sellerId, @RequestParam Integer totalFee) {
+        CouponRequestDto couponRequestDto = new CouponRequestDto(sellerId, totalFee);
         return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "사용자 "+userId+" 님이 "+couponRequestDto.getSellerId()+" 판매자한테 사용할 수 있는 쿠폰 목록입니다.", couponService.getCouponListByDiscountValue(userId, couponRequestDto));
     }
 

--- a/src/main/java/com/feelmycode/parabole/controller/OrderController.java
+++ b/src/main/java/com/feelmycode/parabole/controller/OrderController.java
@@ -40,7 +40,7 @@ public class OrderController {
     @GetMapping
     public ResponseEntity<ParaboleResponse> getOrderList(@RequestAttribute("userId") Long userId) {
         List<Order> orderList = orderService.getOrderList(userId);
-        List<OrderInfoResponseDto> orderInfoResponseDtoList = orderInfoService.getOrderInfoListByUserId(orderList);
+        List<OrderInfoResponseDto> orderInfoResponseDtoList = orderInfoService.getOrderInfoListAlreadyOrdered(orderList);
         return ParaboleResponse.CommonResponse(HttpStatus.OK, true, "모든 주문 정보 호출", orderInfoResponseDtoList);
     }
 }

--- a/src/main/java/com/feelmycode/parabole/domain/Order.java
+++ b/src/main/java/com/feelmycode/parabole/domain/Order.java
@@ -84,11 +84,11 @@ public class Order extends BaseEntity {
     // TODO: enum으로 처리하기
     @NotNull
     @Column(name = "order_state")
-    private OrderState state;
+    private Integer state;
 
     @NotNull
     @Column(name = "order_pay_state")
-    private OrderPayState payState;
+    private Integer payState;
 
     private void setTotal(List<OrderInfo> orderInfoList) {
         this.total = orderInfoList
@@ -97,20 +97,12 @@ public class Order extends BaseEntity {
             .sum();
     }
 
-    public void setPayState(String payState) {
-        this.payState = OrderPayState.returnValueByName(payState);
-    }
-
     public void setState(String state) {
-        this.state = OrderState.returnValueByName(state);
+        this.state = OrderState.returnValueByName(state).getValue();
     }
 
     public void setState(Integer value) {
-        this.state = OrderState.returnNameByValue(value);
-    }
-
-    private void setDeliveryFee(Long orderDeliveryFee) {
-        this.deliveryFee = orderDeliveryFee;
+        this.state = value;
     }
 
     public Order(User user, Long deliveryFee) {
@@ -120,8 +112,8 @@ public class Order extends BaseEntity {
         this.addressSimple = "";
         this.addressDetail = "";
         this.deliveryComment = "";
-        this.state = OrderState.ERROR;
-        this.payState = OrderPayState.ERROR;
+        this.state = -1;
+        this.payState = -1;
         this.setState(-1);
     }
 
@@ -134,7 +126,7 @@ public class Order extends BaseEntity {
         this.addressSimple = deliveryDto.getAddressSimple();
         this.addressDetail = deliveryDto.getAddressDetail();
         this.deliveryComment = deliveryDto.getDeliveryComment();
-        this.payState = deliveryDto.getOrderPayState();
+        this.payState = deliveryDto.getOrderPayState().getValue();
         return this;
     }
 

--- a/src/main/java/com/feelmycode/parabole/domain/Order.java
+++ b/src/main/java/com/feelmycode/parabole/domain/Order.java
@@ -1,7 +1,6 @@
 package com.feelmycode.parabole.domain;
 
 import com.feelmycode.parabole.dto.OrderRequestDto;
-import com.feelmycode.parabole.enumtype.OrderPayState;
 import com.feelmycode.parabole.enumtype.OrderState;
 import com.sun.istack.NotNull;
 import java.util.ArrayList;
@@ -126,7 +125,7 @@ public class Order extends BaseEntity {
         this.addressSimple = deliveryDto.getAddressSimple();
         this.addressDetail = deliveryDto.getAddressDetail();
         this.deliveryComment = deliveryDto.getDeliveryComment();
-        this.payState = deliveryDto.getOrderPayState().getValue();
+        this.payState = deliveryDto.getOrderPayState();
         return this;
     }
 

--- a/src/main/java/com/feelmycode/parabole/domain/Order.java
+++ b/src/main/java/com/feelmycode/parabole/domain/Order.java
@@ -1,6 +1,7 @@
 package com.feelmycode.parabole.domain;
 
 import com.feelmycode.parabole.dto.OrderRequestDto;
+import com.feelmycode.parabole.enumtype.OrderPayState;
 import com.feelmycode.parabole.enumtype.OrderState;
 import com.sun.istack.NotNull;
 import java.util.ArrayList;
@@ -125,7 +126,7 @@ public class Order extends BaseEntity {
         this.addressSimple = deliveryDto.getAddressSimple();
         this.addressDetail = deliveryDto.getAddressDetail();
         this.deliveryComment = deliveryDto.getDeliveryComment();
-        this.payState = deliveryDto.getOrderPayState();
+        this.payState = OrderPayState.returnValueByName(deliveryDto.getOrderPayState()).getValue();
         return this;
     }
 

--- a/src/main/java/com/feelmycode/parabole/domain/OrderInfo.java
+++ b/src/main/java/com/feelmycode/parabole/domain/OrderInfo.java
@@ -37,7 +37,7 @@ public class OrderInfo extends BaseEntity {
 
     // 배송의 상태
     @Column(name = "order_info_state")
-    private OrderInfoState state;
+    private Integer state;
 
     @NotNull
     @Column(name = "product_id")
@@ -68,15 +68,15 @@ public class OrderInfo extends BaseEntity {
     private String sellerStoreName;
 
     public void setState(Integer state) {
-        this.state = OrderInfoState.returnNameByValue(state);
+        this.state = state;
     }
 
     public void setState(String state) {
-        this.state = OrderInfoState.returnValueByName(state);
+        this.state = OrderInfoState.returnValueByName(state).getValue();
     }
 
     public void setState(OrderInfoState state) {
-        this.state = state;
+        this.state = state.getValue();
     }
 
     public void setUserCoupon(UserCoupon userCoupon) {
@@ -96,7 +96,7 @@ public class OrderInfo extends BaseEntity {
     }
 
     public OrderInfoResponseDto toDto() {
-        return new OrderInfoResponseDto(id, state.getState(),
+        return new OrderInfoResponseDto(id, OrderInfoState.returnNameByValue(state).getState(),
             order.getUser().getEmail(), productId, productName, productCnt, productPrice,
             productDiscountPrice, "", getUpdatedAt());
     }

--- a/src/main/java/com/feelmycode/parabole/dto/OrderInfoRequestDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/OrderInfoRequestDto.java
@@ -9,11 +9,11 @@ import lombok.RequiredArgsConstructor;
 public class OrderInfoRequestDto {
 
     private Long orderInfoId;
-    private OrderInfoState orderInfoState;
+    private Integer orderInfoState;
 
     public OrderInfoRequestDto(Long orderInfoId, String orderState) {
         this.orderInfoId = orderInfoId;
-        this.orderInfoState = OrderInfoState.returnValueByName(orderState);
+        this.orderInfoState = OrderInfoState.returnValueByName(orderState).getValue();
     }
 
 }

--- a/src/main/java/com/feelmycode/parabole/dto/OrderInfoResponseDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/OrderInfoResponseDto.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 public class OrderInfoResponseDto {
 
     private Long id;
-    private OrderInfoState state;
+    private Integer state;
     private String userEmail;
     private Long productId;
     private String productName;
@@ -25,7 +25,7 @@ public class OrderInfoResponseDto {
     public OrderInfoResponseDto(Long id, String state, String userEmail, Long productId, String productName,
         Integer productCnt, Long productPrice, Long productDiscountPrice, String productThumbnailImg, LocalDateTime productUpdatedAt) {
         this.id = id;
-        this.state = OrderInfoState.returnValueByName(state);
+        this.state = OrderInfoState.returnValueByName(state).getValue();
         this.userEmail = userEmail;
         this.productId = productId;
         this.productName = productName;

--- a/src/main/java/com/feelmycode/parabole/dto/OrderRequestDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/OrderRequestDto.java
@@ -21,24 +21,24 @@ public class OrderRequestDto {
     private String addressSimple;
     private String addressDetail;
     private String deliveryComment;
-    private OrderState orderState;
-    private OrderInfoState orderInfoState;
-    private OrderPayState orderPayState;
+    private Integer orderState;
+    private Integer orderInfoState;
+    private Integer orderPayState;
 
     public OrderRequestDto(String orderPayState) {
-        this.orderPayState = OrderPayState.returnValueByName(orderPayState);
+        this.orderPayState = OrderPayState.returnValueByName(orderPayState).getValue();
     }
 
     public void setOrderState(String orderState) {
-        this.orderState = OrderState.returnValueByName(orderState);
+        this.orderState = OrderState.returnValueByName(orderState).getValue();
     }
 
     public void setOrderState(OrderState orderState) {
-        this.orderState = orderState;
+        this.orderState = orderState.getValue();
     }
 
     public void setOrderInfoState(OrderInfoState orderInfoState) {
-        this.orderInfoState = orderInfoState;
+        this.orderInfoState = orderInfoState.getValue();
     }
 
     public void setUserInfo(String userName, String userEmail) {

--- a/src/main/java/com/feelmycode/parabole/dto/OrderRequestDto.java
+++ b/src/main/java/com/feelmycode/parabole/dto/OrderRequestDto.java
@@ -1,7 +1,6 @@
 package com.feelmycode.parabole.dto;
 
 import com.feelmycode.parabole.enumtype.OrderInfoState;
-import com.feelmycode.parabole.enumtype.OrderPayState;
 import com.feelmycode.parabole.enumtype.OrderState;
 import java.util.List;
 import lombok.Getter;
@@ -21,24 +20,24 @@ public class OrderRequestDto {
     private String addressSimple;
     private String addressDetail;
     private String deliveryComment;
-    private Integer orderState;
-    private Integer orderInfoState;
-    private Integer orderPayState;
+    private String orderState;
+    private String orderInfoState;
+    private String orderPayState;
 
     public OrderRequestDto(String orderPayState) {
-        this.orderPayState = OrderPayState.returnValueByName(orderPayState).getValue();
+        this.orderPayState = orderPayState;
     }
 
     public void setOrderState(String orderState) {
-        this.orderState = OrderState.returnValueByName(orderState).getValue();
+        this.orderState = orderState;
     }
 
     public void setOrderState(OrderState orderState) {
-        this.orderState = orderState.getValue();
+        this.orderState = orderState.getState();
     }
 
     public void setOrderInfoState(OrderInfoState orderInfoState) {
-        this.orderInfoState = orderInfoState.getValue();
+        this.orderInfoState = orderInfoState.getState();
     }
 
     public void setUserInfo(String userName, String userEmail) {

--- a/src/main/java/com/feelmycode/parabole/enumtype/OrderPayState.java
+++ b/src/main/java/com/feelmycode/parabole/enumtype/OrderPayState.java
@@ -30,4 +30,11 @@ public enum OrderPayState {
             .orElse(ERROR);
     }
 
+    public static OrderPayState returnNameByValue(Integer value) {
+        return Arrays.stream(values())
+                .filter(orderPayState -> orderPayState.getValue() == value)
+                .findAny()
+                .orElse(ERROR);
+    }
+
 }

--- a/src/main/java/com/feelmycode/parabole/service/OrderInfoService.java
+++ b/src/main/java/com/feelmycode/parabole/service/OrderInfoService.java
@@ -109,6 +109,20 @@ public class OrderInfoService {
         return changeEntityToDto(getOrderInfoList);
     }
 
+    public List<OrderInfoResponseDto> getOrderInfoListAlreadyOrdered(List<Order> orders) {
+        List<OrderInfo> orderInfoList = new ArrayList<>();
+
+        for(Order order : orders) {
+            if(order.getState() >= 0) {
+                orderInfoList.addAll(orderInfoRepository.findAllByOrderId(order.getId())
+                    .stream()
+                    .filter(orderInfo -> orderInfo.getState() > -1)
+                    .collect(Collectors.toList()));
+            }
+        }
+        return this.changeEntityToDto(orderInfoList);
+    }
+
     public List<OrderInfo> getOrderInfoListByOrderId(Long orderId) {
         return orderInfoRepository.findAllByOrderId(orderId);
     }
@@ -117,7 +131,9 @@ public class OrderInfoService {
 
         Long cnt = 0L;
 
-        List<OrderInfo> orderInfoList = orderInfoRepository.findAllBySellerId(userId);
+        Order order = orderService.getOrderByUserId(userId);
+
+        List<OrderInfo> orderInfoList = orderInfoRepository.findAllByOrderId(order.getId());
 
         if(orderInfoList == null || orderInfoList.isEmpty())
             throw new ParaboleException(HttpStatus.BAD_REQUEST, "주문 내역이 없습니다.");

--- a/src/main/java/com/feelmycode/parabole/service/OrderInfoService.java
+++ b/src/main/java/com/feelmycode/parabole/service/OrderInfoService.java
@@ -90,7 +90,7 @@ public class OrderInfoService {
     public boolean isDeliveryComplete(Long userId) {
         List<OrderInfoResponseDto> orderInfoResponseDtoList = getOrderInfoListByUserId(userId);
         return orderInfoResponseDtoList.stream()
-            .allMatch(dto -> dto.getState().getValue() > 5);
+            .allMatch(dto -> dto.getState() > 5);
     }
 
     public List<OrderInfoResponseDto> getOrderInfoListByUserId(Long userId) {
@@ -104,7 +104,7 @@ public class OrderInfoService {
     public List<OrderInfoResponseDto> getOrderInfoListBySeller(Long sellerId) {
         List<OrderInfo> getOrderInfoList = orderInfoRepository.findAllBySellerId(sellerId)
             .stream()
-            .filter(state -> state.getState().getValue() > -1)
+            .filter(state -> state.getState() > -1)
             .collect(Collectors.toList());
         return changeEntityToDto(getOrderInfoList);
     }

--- a/src/main/java/com/feelmycode/parabole/service/OrderService.java
+++ b/src/main/java/com/feelmycode/parabole/service/OrderService.java
@@ -27,7 +27,7 @@ public class OrderService {
     public List<Order> getOrderList(Long userId) {
         List<Order> orderList = orderRepository.findAllByUserId(userId)
             .stream()
-            .filter(order -> order.getState().getValue() > -1)
+            .filter(order -> order.getState() > -1)
             .collect(Collectors.toList());
         return orderList;
     }
@@ -55,7 +55,7 @@ public class OrderService {
         if (order == null) {
             return;
         }
-        if (order.getState().getValue() < 0) {
+        if (order.getState() < 0) {
             this.deleteOrder(order.getId());
         }
     }

--- a/src/main/java/com/feelmycode/parabole/service/UpdateService.java
+++ b/src/main/java/com/feelmycode/parabole/service/UpdateService.java
@@ -96,7 +96,7 @@ public class UpdateService {
                 throw new NoDataException();
             }
             for(Long orderInfoId : orderInfoRequestList.getOrderInfoIdList()) {
-                this.updateOrderInfoState(userId, new OrderInfoRequestDto(orderInfoId, OrderInfoState.returnNameByValue(orderUpdateRequestDto.getOrderInfoState()).getState()));
+                this.updateOrderInfoState(userId, new OrderInfoRequestDto(orderInfoId, OrderInfoState.returnValueByName(orderUpdateRequestDto.getOrderInfoState()).getState()));
             }
         }
 

--- a/src/main/java/com/feelmycode/parabole/service/UpdateService.java
+++ b/src/main/java/com/feelmycode/parabole/service/UpdateService.java
@@ -58,7 +58,7 @@ public class UpdateService {
                 }
 
                 this.updateOrderState(userId, new OrderRequestDto(
-                    order.getPayState().getState()));
+                    OrderPayState.returnNameByValue(order.getPayState()).getState()));
             }
         } catch (Exception e) {
             throw new ParaboleException(HttpStatus.UNAUTHORIZED, "주문정보를 수정하는 중 문제가 발생했습니다.");
@@ -73,8 +73,8 @@ public class UpdateService {
             throw new NoDataException();
         }
 
-        if(order.getState().getValue() < 2) {
-            order.setState(order.getState().getValue()+1);
+        if(order.getState() < 2) {
+            order.setState(order.getState()+1);
             orderUpdateRequestDto.setOrderState(OrderState.PAY_COMPLETE);
         } else {
             throw new ParaboleException(HttpStatus.BAD_REQUEST, "이미 배송완료된 상품입니다.");
@@ -104,7 +104,7 @@ public class UpdateService {
         orderInfoService.setCouponToOrderInfo(userId, orderUpdateRequestDto);
 
         // 주문이 완료 되었을 때 cart에 있는 아이템 삭제
-        if (order.getState().getValue() == 0) {
+        if (order.getState() == 0) {
             Cart getCart = cartService.getCart(userId);
 
             List<CartItem> cartItemList = cartItemRepository.findAllByCartId(getCart.getId());

--- a/src/main/java/com/feelmycode/parabole/service/UpdateService.java
+++ b/src/main/java/com/feelmycode/parabole/service/UpdateService.java
@@ -54,7 +54,7 @@ public class UpdateService {
                 List<OrderInfo> getOrderInfoList = orderInfoService.getOrderInfoListByOrderId(order.getId());
 
                 for (OrderInfo info : getOrderInfoList) {
-                    info.setState(orderInfoRequestDto.getOrderInfoState().getValue());
+                    info.setState(orderInfoRequestDto.getOrderInfoState());
                 }
 
                 this.updateOrderState(userId, new OrderRequestDto(
@@ -96,7 +96,7 @@ public class UpdateService {
                 throw new NoDataException();
             }
             for(Long orderInfoId : orderInfoRequestList.getOrderInfoIdList()) {
-                this.updateOrderInfoState(userId, new OrderInfoRequestDto(orderInfoId, orderUpdateRequestDto.getOrderInfoState().getState()));
+                this.updateOrderInfoState(userId, new OrderInfoRequestDto(orderInfoId, OrderInfoState.returnNameByValue(orderUpdateRequestDto.getOrderInfoState()).getState()));
             }
         }
 


### PR DESCRIPTION
## 개요
enum을 저장할 때 index0부터 들어가는데 음수 값을 넣어야 하기 때문에 Integer로 수정하는 작업 수행

## 작업한 내용
1. Change Enum to Integer
2. 사용자의 id를 통해서 주문정보를 가져오고 그 주문에 일치하는 상세주문을 가져오는 부분으로 수정

## 테스트 결과
![image](https://user-images.githubusercontent.com/21255149/201801049-7343e9b7-44fa-45b7-9749-e2b58d0c2ff9.png)

## 이슈번호
[#176]
