### PR TITLE
HOTFix: 회원가입시 장바구니 생성 안되던 오류 수정

### DIFF
--- a/src/main/java/com/feelmycode/parabole/service/CartService.java
+++ b/src/main/java/com/feelmycode/parabole/service/CartService.java
@@ -18,6 +18,7 @@ public class CartService {
     private final CartRepository cartRepository;
     private final UserRepository userRepository;
 
+    @Transactional
     public Long createCart(Long userId) {
         checkNoCart(userId);
         User user = userRepository.findById(userId).orElseThrow(() ->


### PR DESCRIPTION
## 개요

회원가입시 장바구니 생성 안되던 오류 수정

## 작업한 내용

- 회원가입시 장바구니 생성 안되던 오류 수정

